### PR TITLE
Add generic CloudStore methods

### DIFF
--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -1,31 +1,3 @@
-"""
-CloudBase provides very simple HTTP clients for cloud services
-(AWS, Azure, Google Cloud), which consists of 2 main components:
-  * Computing credentials necessary for authenticated cloud requests
-  * Signing requests with the credentials
-
-CloudStore provides a very simple, consistent, and performant API for
-object management with cloud services.
-  * Create/list/delete buckets/containers
-  * Put object
-    * in single operation
-    * from existing object (copy)
-    * for large objects, split into parts and upload in parallel
-    * from ObjectWithParts, replace parts with new data, and upload in parallel (using UploadPartCopy/Put Block List w/ committed parts)
-  * Get Object
-    * get object metadata
-    * get object in single operation
-    * get large objects in parallel, either by concurrent parts/block, or by concurrent range requests
-  * list objects in bucket/container
-
-* allow compressing objects auto when putting; decompressing auto when getting
-* allow public get from s3:// azure:// urls
-
-Object model:
-  * Bucket/Container: returned from create, list, arg for object operations, can create manually
-  * Object: returned from put, get, list objects. can be used for put/get. 
-
-"""
 module CloudStore
 
 using HTTP, CodecZlib, Mmap
@@ -40,6 +12,9 @@ const MULTIPART_SIZE = 16_000_000
 
 defaultBatchSize() = 4 * Threads.nthreads()
 
+asArray(x::Array) = x
+asArray(x) = [x]
+
 struct Object
     store::AbstractStore
     key::String
@@ -50,11 +25,130 @@ struct Object
 end
 
 etag(x) = strip(x, '"')
-object(b, x) = Object(b, x["Key"], x["LastModified"], etag(x["ETag"]), parse(Int, x["Size"]), x["StorageClass"])
 
 include("get.jl")
 include("put.jl")
 include("s3.jl")
 include("blob.jl")
+
+get(x::Object, out::ResponseBodyType=nothing; kw...) = get(x.store, x.key, out; kw...)
+head(x::Object; kw...) = head(x.store, x.key; kw...)
+put(x::Object, in::RequestBodyType; kw...) = put(x.store, x.key, in; kw...)
+delete(x::Object; kw...) = delete(x.store, x.key; kw...)
+
+# generic methods that dispatch on store type
+list(x::AWS.Bucket; kw...) = S3.list(x; kw...)
+get(x::AWS.Bucket, key::String, out::ResponseBodyType=nothing; kw...) = S3.get(x, key, out; kw...)
+head(x::AWS.Bucket, key::String; kw...) = S3.head(x, key; kw...)
+put(x::AWS.Bucket, key::String, in::RequestBodyType; kw...) = S3.put(x, key, in; kw...)
+delete(x::AWS.Bucket, key::String; kw...) = S3.delete(x, key; kw...)
+
+list(x::Azure.Container; kw...) = Azure.list(x; kw...)
+get(x::Azure.Container, key::String, out::ResponseBodyType=nothing; kw...) = Azure.get(x, key, out; kw...)
+head(x::Azure.Container, key::String; kw...) = Azure.head(x, key; kw...)
+put(x::Azure.Container, key::String, in::RequestBodyType; kw...) = Azure.put(x, key, in; kw...)
+delete(x::Azure.Container, key::String; kw...) = Azure.delete(x, key; kw...)
+
+# try to parse cloud-specific url schemes and dispatch
+function parseAzureAccountContainerBlob(url)
+    # https://myaccount.blob.core.windows.net/mycontainer/myblob
+    m = match(r"^https://(?<account>[^\.]+)\.blob\.core\.windows\.net/(?<container>[^/]+)/(?<blob>.+)$", url)
+    m !== nothing && return (true, String(m[:account]), String(m[:container]), String(m[:blob]))
+    # https://myaccount.blob.core.windows.net/mycontainer
+    m = match(r"^https://(?<account>[^\.]+)\.blob\.core\.windows\.net/(?<container>[^/]+)$", url)
+    m !== nothing && return (true, String(m[:account]), String(m[:container]), "")
+    return (false, "", "", "")
+end
+
+function parseAWSBucketRegionKey(url)
+    # https://bucket-name.s3.region-code.amazonaws.com/key-name
+    m = match(r"^https://(?<bucket>[^\.]+)\.s3\.(?<region>[^\.]+)\.amazonaws\.com/(?<key>.+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), String(m[:region]), String(m[:key]))
+    # https://bucket-name.s3.region-code.amazonaws.com
+    m = match(r"^https://(?<bucket>[^\.]+)\.s3\.(?<region>[^\.]+)\.amazonaws\.com$", url)
+    m !== nothing && return (true, String(m[:bucket]), String(m[:region]), "")
+    # https://bucket-name.s3.amazonaws.com/key-name
+    m = match(r"^https://(?<bucket>[^\.]+)\.s3\.amazonaws\.com/(?<key>.+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), "", String(m[:key]))
+    # https://bucket-name.s3.amazonaws.com
+    m = match(r"^https://(?<bucket>[^\.]+)\.s3\.amazonaws\.com$", url)
+    m !== nothing && return (true, String(m[:bucket]), "", "")
+    # https://s3.region-code.amazonaws.com/bucket-name/key-name
+    m = match(r"^https://s3\.(?<region>[^\.]+)\.amazonaws\.com/(?<bucket>[^/]+)/(?<key>.+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), String(m[:region]), String(m[:key]))
+    # https://s3.region-code.amazonaws.com/bucket-name
+    m = match(r"^https://s3\.(?<region>[^\.]+)\.amazonaws\.com/(?<bucket>[^/]+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), String(m[:region]), "")
+    # S3://bucket-name/key-name
+    m = match(r"^s3://(?<bucket>[^/]+)/(?<key>.+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), "", String(m[:key]))
+    # S3://bucket-name
+    m = match(r"^s3://(?<bucket>[^/]+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), "", "")
+    return (false, "", "", "")
+end
+
+function parseGCPBucketObject(url)
+    # https://storage.googleapis.com/BUCKET_NAME/OBJECT_NAME
+    m = match(r"^https://storage\.googleapis\.com/(?<bucket>[^/]+)/(?<object>.+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), String(m[:object]))
+    # https://storage.googleapis.com/BUCKET_NAME
+    m = match(r"^https://storage\.googleapis\.com/(?<bucket>[^/]+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), "")
+    # https://BUCKET_NAME.storage.googleapis.com/OBJECT_NAME
+    m = match(r"^https://(?<bucket>[^\.]+)\.storage\.googleapis\.com/(?<object>.+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), String(m[:object]))
+    # https://BUCKET_NAME.storage.googleapis.com
+    m = match(r"^https://(?<bucket>[^\.]+)\.storage\.googleapis\.com$", url)
+    m !== nothing && return (true, String(m[:bucket]), "")
+    # https://storage.googleapis.com/download/storage/v1/b/BUCKET_NAME/o/OBJECT_NAME?alt=media
+    m = match(r"^https://storage\.googleapis\.com/download/storage/v1/b/(?<bucket>[^/]+)/o/(?<object>.+)\?alt=media$", url)
+    m !== nothing && return (true, String(m[:bucket]), String(m[:object]))
+    # https://storage.googleapis.com/download/storage/v1/b/BUCKET_NAME
+    m = match(r"^https://storage\.googleapis\.com/download/storage/v1/b/(?<bucket>[^/]+)$", url)
+    m !== nothing && return (true, String(m[:bucket]), "")
+    return (false, "", "")
+end
+
+function parseURLForDispatch(url, region, nowarn)
+    # try to parse cloud-specific url schemes and dispatch
+    ok, bucket, reg, key = parseAWSBucketRegionKey(url)
+    region = isempty(reg) ? region : reg
+    if region === nothing
+        nowarn || @warn "`region` keyword argument not provided to `CloudStore.get` and undetected from url.  Defaulting to `us-east-1`"
+        region = AWS.AWS_DEFAULT_REGION
+    end
+    ok && return (AWS.Bucket(bucket, region), key)
+    ok, account, container, blob = parseAzureAccountContainerBlob(url)
+    ok && return (Azure.Container(container, account), blob)
+    # ok, bucket, object = parseGCPBucketObject(url)
+    # ok && return (GCP.Bucket(bucket), object)
+    error("couldn't determine cloud from string url: `$url`")
+end
+
+function get(url::String, out::ResponseBodyType=nothing; region=nothing, nowarn::Bool=false, kw...)
+    store, key = parseURLForDispatch(url, region, nowarn)
+    return get(store, key, out; kw...)
+end
+
+function head(url::String; region=nothing, nowarn::Bool=false, kw...)
+    store, key = parseURLForDispatch(url, region, nowarn)
+    return head(store, key; kw...)
+end
+
+function put(url::String, in::RequestBodyType; region=nothing, nowarn::Bool=false, kw...)
+    store, key = parseURLForDispatch(url, region, nowarn)
+    return put(store, key, in; kw...)
+end
+
+function delete(url::String; region=nothing, nowarn::Bool=false, kw...)
+    store, key = parseURLForDispatch(url, region, nowarn)
+    return delete(store, key; kw...)
+end
+
+function list(url::String; region=nothing, nowarn::Bool=false, kw...)
+    store, _ = parseURLForDispatch(url, region, nowarn)
+    return list(store; kw...)
+end
 
 end # module CloudStore

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -1,14 +1,48 @@
 module Blobs
 
 using CloudBase.Azure, XMLDict, HTTP, CodecZlib, Base64
-import ..ResponseBodyType, ..RequestBodyType, ..getObject, ..putObject, ..Object, ..etag, ..object
+import ..ResponseBodyType, ..RequestBodyType, ..getObject, ..putObject, ..Object, ..etag, ..asArray
 
 const Container = Azure.Container
+
+object(b, x) = Object(b, x["Name"], x["Properties"]["Last-Modified"], etag(x["Properties"]["Etag"]), parse(Int, x["Properties"]["Content-Length"]), "")
+
+function list(x::Container; prefix="", maxKeys=5000, kw...)
+    if maxKeys > 5000
+        @warn "Azure only supports 5000 keys per request: `$maxKeys` requested"
+        maxKeys = 5000
+    end
+    query = Dict("restype" => "container", "comp" => "list")
+    if !isempty(prefix)
+        query["prefix"] = prefix
+    end
+    if maxKeys != 5000
+        query["maxresults"] = string(maxKeys)
+    end
+    result = xml_dict(String(Azure.get(x.baseurl; query, kw...).body))["EnumerationResults"]
+    if isempty(result["Blobs"])
+        return Object[]
+    end
+    contents = map(y -> object(x, y), asArray(result["Blobs"]["Blob"]))
+    while !isempty(result["NextMarker"])
+        query["marker"] = result["NextMarker"]
+        result = xml_dict(String(Azure.get(x.baseurl; query, kw...).body))["EnumerationResults"]
+        if !isempty(result["Blobs"])
+            append!(contents, map(y -> object(x, y), asArray(result["Blobs"]["Blob"])))
+        else
+            break
+        end
+    end
+    return contents
+end
 
 get(x::Object, out::ResponseBodyType=nothing; kw...) = get(x.store, x.key, out; kw...)
 function get(x::Container, key::String, out::ResponseBodyType=nothing; kw...)
     return getObject(Azure, joinpath(x.baseurl, key), out, "blob"; kw...)
 end
+
+head(x::Object; kw...) = head(x.store, x.key; kw...)
+head(x::Container, key::String; kw...) = Dict(Azure.get(joinpath(x.baseurl, key); query=Dict("comp" => "metadata"), kw...).headers)
 
 put(x::Container, key::String, in::RequestBodyType; kw...) =
     putObject(Blobs, x, key, in; kw...)
@@ -28,5 +62,8 @@ function completeMultipartUpload(url, eTags, uploadId; kw...)
     resp = Azure.put(url; query=Dict("comp" => "blocklist"), body, kw...)
     return etag(HTTP.header(resp, "ETag"))
 end
+
+delete(x::Container, key::String; kw...) = Azure.delete(joinpath(x.baseurl, key); kw...)
+delete(x::Object; kw...) = delete(x.store, x.key; kw...)
 
 end # module Blobs

--- a/src/get.jl
+++ b/src/get.jl
@@ -6,11 +6,13 @@ function parseContentRange(str)
 end
 
 function getObject(mod, url::String, out::ResponseBodyType, service;
-    decompress::Bool=false,
-    partSize::Int=MULTIPART_SIZE,
     multipartThreshold::Int=MULTIPART_THRESHOLD,
-    batchSize::Int=defaultBatchSize(), kw...)
-    rng = 0:(multipartThreshold - 1)
+    partSize::Int=MULTIPART_SIZE,
+    batchSize::Int=defaultBatchSize(),
+    allowMultipart::Bool=true,
+    decompress::Bool=false, kw...)
+
+    rng = allowMultipart ? (0:(multipartThreshold - 1)) : nothing
     if out === nothing
         resp = request(mod, url, rng, service; kw...)
         res = resp.body
@@ -24,32 +26,37 @@ function getObject(mod, url::String, out::ResponseBodyType, service;
         res = decompress ? GzipDecompressorStream(out) : out
         resp = request(mod, url, rng, service; response_stream=res, kw...)
     end
-    soff, eoff, total = parseContentRange(HTTP.header(resp, "Content-Range"))
-    if (eoff + 1) < total
-        nTasks = cld(total - eoff, partSize)
-        nLoops = cld(nTasks, batchSize)
-        sync = OrderedSynchronizer(1)
-        if res isa Vector{UInt8}
-            resize!(res, total)
-        end
-        for j = 1:nLoops
-            @sync for i = 1:batchSize
-                n = (j - 1) * batchSize + i
-                n > nTasks && break
-                let n=n
-                    Threads.@spawn begin
-                        rng = ((n - 1) * partSize + eoff + 1):min(total, (n * partSize) + eoff)
-                        #TODO: in HTTP.jl, allow passing res as response_stream that we write to directly
-                        resp = request(mod, url, rng, service; kw...)
-                        let resp=resp
-                            if res isa Vector{UInt8}
-                                off, off2, _ = parseContentRange(HTTP.header(resp, "Content-Range"))
-                                put!(sync, n) do
-                                    copyto!(res, off + 1, resp.body, 1, off2 - off + 1)
-                                end
-                            else
-                                put!(sync, n) do
-                                    write(res, resp.body)
+    if allowMultipart
+        soff, eoff, total = parseContentRange(HTTP.header(resp, "Content-Range"))
+        if (eoff + 1) < total
+            nTasks = cld(total - eoff, partSize)
+            nLoops = cld(nTasks, batchSize)
+            sync = OrderedSynchronizer(1)
+            if res isa Vector{UInt8}
+                resize!(res, total)
+            end
+            for j = 1:nLoops
+                @sync for i = 1:batchSize
+                    n = (j - 1) * batchSize + i
+                    n > nTasks && break
+                    let n=n
+                        Threads.@spawn begin
+                            rng = ((n - 1) * partSize + eoff + 1):min(total, (n * partSize) + eoff)
+                            #TODO: in HTTP.jl, allow passing res as response_stream that we write to directly
+                            resp = request(mod, url, rng, service; kw...)
+                            #TODO: verify Last-Modified in resp matches from 1st response?
+                            #TODO: do If-Match eTag w/ AWS?
+                            #TODO: pass generation for each GCP request?
+                            let resp=resp
+                                if res isa Vector{UInt8}
+                                    off, off2, _ = parseContentRange(HTTP.header(resp, "Content-Range"))
+                                    put!(sync, n) do
+                                        copyto!(res, off + 1, resp.body, 1, off2 - off + 1)
+                                    end
+                                else
+                                    put!(sync, n) do
+                                        write(res, resp.body)
+                                    end
                                 end
                             end
                         end
@@ -70,6 +77,6 @@ function getObject(mod, url::String, out::ResponseBodyType, service;
     return res
 end
 
-function request(mod, url, rng, service; kw...)
-    return mod.get(url, ["Range" => "bytes=$(first(rng))-$(last(rng))"]; service, kw...)
-end
+request(mod, url, ::Nothing, service; kw...) = mod.get(url; service, kw...)
+request(mod, url, rng, service; kw...) =
+    mod.get(url, ["Range" => "bytes=$(first(rng))-$(last(rng))"]; service, kw...)


### PR DESCRIPTION
We allow dispatching on either the store type (AWS.Bucket or Azure.Container for now)
or you can just provide a cloud url and we'll try to figure out where to direct it.

I think this API has unfolded really nicely because you can imagine this being really convenient
for like, kaggle competitions where I have a public s3 url that I'd like to be able to use
the concurrent downloading capabilities with and just call `CloudStore.get(url)`.

This also provides a couple of options for workflows where you really want to interface w/ different
cloud providers: provide the different urls or construct the cloud-specific stores and then dispatch.