### PR TITLE
Ensure users can pass through query/headers for get operations

### DIFF
--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -12,8 +12,12 @@ using HTTP, CodecZlib, Mmap
 import WorkerUtilities: OrderedSynchronizer
 import CloudBase: AbstractStore
 
-const MULTIPART_THRESHOLD = 64_000_000
-const MULTIPART_SIZE = 16_000_000
+"""
+Controls the automatic use of concurrency when downloading/uploading.
+  * Downloading: the size of the initial content range requested; if 
+"""
+const MULTIPART_THRESHOLD = 2^23 # 8MB
+const MULTIPART_SIZE = 2^23
 
 defaultBatchSize() = 4 * Threads.nthreads()
 

--- a/src/blobs.jl
+++ b/src/blobs.jl
@@ -26,13 +26,7 @@ end
 
 list(x::Container; kw...) = API.listObjectsImpl(x; kw...)
 
-function API.getObject(x::Container, url, rng; kw...)
-    if rng === nothing
-        return Azure.get(url; kw...)
-    else
-        return Azure.get(url, [rng]; kw...)
-    end
-end
+API.getObject(x::Container, url, headers; kw...) = Azure.get(url, headers; kw...)
 
 get(x::Object, args...; kw...) = get(x.store, x.key, args...; kw...)
 get(args...; kw...) = API.getObjectImpl(args...; kw...)

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -35,13 +35,7 @@ end
 
 list(x::Bucket; kw...) = API.listObjectsImpl(x; kw...)
 
-function API.getObject(x::Bucket, url, rng; kw...)
-    if rng === nothing
-        return AWS.get(url; service="s3", kw...)
-    else
-        return AWS.get(url, [rng, "x-amz-checksum-mode" => "ENABLED"]; service="s3", kw...)
-    end
-end
+API.getObject(x::Bucket, url, headers; kw...) = AWS.get(url, headers; service="s3", kw...)
 
 get(x::Object, out::ResponseBodyType=nothing; kw...) = get(x.store, x.key, out; kw...)
 get(args...; kw...) = API.getObjectImpl(args...; kw...)


### PR DESCRIPTION
This enables users to pass `versionId` if desired via `query` keyword arg which fixed #9.