### PR TITLE
Better support for 0-byte object getting

### DIFF
--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -45,6 +45,7 @@ function continuationToken end
 function listObjects end
 makeURL(x::AbstractStore, key) = joinpath(x.baseurl, lstrip(key, '/'))
 function getObject end
+function headObject end
 include("get.jl")
 function putObject end
 function startMultipartUpload end

--- a/src/blobs.jl
+++ b/src/blobs.jl
@@ -32,8 +32,9 @@ API.getObject(x::Container, url, headers; kw...) = Azure.get(url, headers; kw...
 get(x::Object, args...; kw...) = get(x.store, x.key, args...; kw...)
 get(args...; kw...) = API.getObjectImpl(args...; kw...)
 
+API.headObject(x::Container, url, headers; kw...) = Azure.head(url; headers, kw...)
 head(x::Object; kw...) = head(x.store, x.key; kw...)
-head(x::Container, key::String; kw...) = Dict(Azure.get(API.makeURL(x, key); query=Dict("comp" => "metadata"), kw...).headers)
+head(x::Container, key::String; kw...) = API.headObjectImpl(x, key; kw...)
 
 put(args...; kw...) = API.putObjectImpl(args...; kw...)
 put(x::Object; kw...) = put(x.store, x.key; kw...)

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -31,8 +31,9 @@ API.getObject(x::Bucket, url, headers; kw...) = AWS.get(url, headers; service="s
 get(x::Object, out::ResponseBodyType=nothing; kw...) = get(x.store, x.key, out; kw...)
 get(args...; kw...) = API.getObjectImpl(args...; kw...)
 
+API.headObject(x::Bucket, url, headers; kw...) = AWS.head(url; headers, service="s3", kw...)
 head(x::Object; kw...) = head(x.store, x.key; kw...)
-head(x::Bucket, key::String; kw...) = Dict(AWS.head(API.makeURL(x, key); service="s3", kw...).headers)
+head(x::Bucket, key::String; kw...) = API.headObjectImpl(x, key; kw...)
 
 put(args...; kw...) = API.putObjectImpl(args...; kw...)
 put(x::Object; kw...) = put(x.store, x.key; kw...)


### PR DESCRIPTION
Ok, quite the rabbit hole here, but I got to explore an odd dark corner of the internet in the process. Here goes: so our strategy for downloading/getting was this:
  * make an initial Range request of 0-8MB 
    * if object is smaller than 8MB, no problem, it returns 206 anyway and we don't make any more requests 
    * if object is bigger, it tells us total object size in Content-Range header and we continue w/ concurrency
  * BUT, it turns out if the requested object happens to be empty, i.e. 0-bytes, the Range request fails with a 416 status response, "Range not satisfiable". What??

Indeed, it turns out the RFC states pretty clearly that if the requested object is empty, then a 416 should be returned for Range requests. It does, however, say you can make a Range request like `Range: bytes=-1` with any non-zero number and *that's* ok (again, what??).

Alright, so we can't just dive into doing Range-ed GET requests.

So this PR implements the following strategy:
  * We make an inital HEAD request on the object
  * This returns the `Content-Length` response header that tells us if the requested object is 0 bytes
  * If so: we short circuit the whole get operation and return the 0-byte body in whatever form provided
  * Otherwise: we continue forward w/ our Range-ed GET requests

So net-net, for 0-byte objects, this is no overhead since we're still just doing 1 total request. For > 0 byte objects, we're doing 1 extra HEAD request, which for large, multipart downloads shouldn't even be noticeable. For smaller objects, this isn't ideal because we're essentially doubling the # of requests, but I'm not sure we can do any better in this generic setting. For now, if you know your objects are non-zero length, and you don't need multipart downloading, you can pass `allowMultipart=false` and we won't do the extra HEAD request. That seems good enough for now.