### PR TITLE
Fix a couple off-by-one errors for ranged downloads

### DIFF
--- a/src/put.jl
+++ b/src/put.jl
@@ -54,6 +54,9 @@ function putObjectImpl(x::AbstractStore, key::String, in::RequestBodyType;
     if N <= multipartThreshold || !allowMultipart
         body = prepBody(in, compress)
         resp = putObject(x, key, body; credentials, kw...)
+        if resp.status != 200
+            @error String(resp.body)
+        end
         return Object(x, credentials, key, N, etag(HTTP.header(resp, "ETag")))
     end
     # multipart upload


### PR DESCRIPTION
If an object size was 1) larger than default partsize (8MB default) and 2) a perfect power of partSize, then there was a corner case where we tried to do one extra range request for 1 extra byte after we already finished, but this ends up throwing an invalid range request error.