### PR TITLE
Introduce a prefetched stream object

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,9 @@ XMLDict = "0.4"
 julia = "1.6"
 
 [extras]
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+
 [targets]
-test = ["Test"]
+test = ["CodecZlib", "Test"]

--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -6,7 +6,7 @@ import CloudBase: AWS, Azure, CloudTest
 # for specific clouds
 module API
 
-export Object, IOObject, ResponseBodyType, RequestBodyType
+export Object, IOObject, PrefechedDownloadStream, ResponseBodyType, RequestBodyType
 
 using HTTP, CodecZlib, Mmap
 import WorkerUtilities: OrderedSynchronizer
@@ -14,7 +14,7 @@ import CloudBase: AbstractStore
 
 """
 Controls the automatic use of concurrency when downloading/uploading.
-  * Downloading: the size of the initial content range requested; if 
+  * Downloading: the size of the initial content range requested; if
 """
 const MULTIPART_THRESHOLD = 2^23 # 8MB
 const MULTIPART_SIZE = 2^23

--- a/src/object.jl
+++ b/src/object.jl
@@ -88,6 +88,11 @@ function Base.readbytes!(x::IOObject, dest::AbstractVector{UInt8}, n::Integer=le
     return dest
 end
 
+mutable struct TaskCondition
+    cond_wait::Threads.Condition
+    ntasks::Int
+end
+TaskCondition() = TaskCondition(Threads.Condition(), 0)
 mutable struct PrefetchBuffer
     data::Vector{UInt8}
     pos::Int
@@ -98,17 +103,59 @@ Base.bytesavailable(b::PrefetchBuffer) = b.len - b.pos + 1
 function _prefetching_task(io)
     prefetch_size = io.prefetch_size
     len = io.len
-    object = io.object
     ppos = 1
+    download_buffer = Vector{UInt8}(undef, prefetch_size)
+    download_buffer_next = Vector{UInt8}(undef, prefetch_size)
 
     while len > ppos
-        n = min(bytesavailable(io), prefetch_size)
-        buf = PrefetchBuffer(getRange(object, ppos, n), 1, n)
+        n = min(len - ppos + 1, prefetch_size)
+        off = 0
+        rngs = Iterators.partition(ppos:ppos+n-1, 2*1024*1024)
+        io.cond.ntasks = length(rngs)
+        # @info "expect $(io.cond.ntasks)"
+        for rng in rngs
+            put!(io.download_queue, (off, rng, download_buffer))
+            off += length(rng)
+        end
+        @lock io.cond.cond_wait begin
+            while true
+                # @info "waiting for 0, got $(io.cond.ntasks)"
+                io.cond.ntasks == 0 && break
+                wait(io.cond.cond_wait)
+            end
+        end
+
+        buf = PrefetchBuffer(download_buffer, 1, n)
         ppos += n
-        # unbuffered, blocks until we're done with the previous buffer and `take!` the next one
-        put!(io.queue, buf)
+        put!(io.prefetch_queue, buf)
+        download_buffer, download_buffer_next = download_buffer_next, download_buffer
     end
-    close(io.queue)
+    close(io.prefetch_queue)
+    close(io.download_queue)
+    return nothing
+end
+
+function _download_task(io)
+    headers = HTTP.Headers()
+    object = io.object
+    url = makeURL(object.store, io.object.key)
+    credentials = object.credentials
+
+    while true
+        (off, rng, download_buffer) = take!(io.download_queue)
+        # @info "got $off, $rng, $(length(rng))"
+        HTTP.setheader(headers, contentRange(rng))
+        #TODO: in HTTP.jl, allow passing res as response_stream that we write to directly
+        resp = getObject(object.store, url, headers; credentials)
+
+        unsafe_copyto!(download_buffer, off + 1, resp.body, 1, length(rng))
+
+        @lock io.cond.cond_wait begin
+            # @info "done with $(io.cond.ntasks)"
+            io.cond.ntasks -= 1
+            notify(io.cond.cond_wait)
+        end
+    end
     return nothing
 end
 
@@ -118,7 +165,9 @@ mutable struct PrefechedDownloadStream{T <: Object} <: IO
     len::Int
     buf::Union{Nothing,PrefetchBuffer}
     prefetch_size::Int
-    queue::Channel{PrefetchBuffer}
+    prefetch_queue::Channel{PrefetchBuffer}
+    download_queue::Channel{Tuple{Int,UnitRange{Int},Vector{UInt8}}}
+    cond::TaskCondition
 
     function PrefechedDownloadStream(
         object::T,
@@ -126,8 +175,20 @@ mutable struct PrefechedDownloadStream{T <: Object} <: IO
     ) where {T<:Object}
         len = length(object)
         size = min(prefetch_size, len)
-        io = new{T}(object, 1, len, nothing, size, Channel{PrefetchBuffer}(0))
-        Threads.@spawn _prefetching_task(io)
+        io = new{T}(
+            object,
+            1,
+            len,
+            nothing,
+            size,
+            Channel{PrefetchBuffer}(0),
+            Channel{Tuple{Int,UnitRange{Int},Vector{UInt8}}}(Inf),
+            TaskCondition()
+        )
+        for _ in 1:min(8, max(1, div(size, 2*1024*1024)))
+            Threads.@spawn _download_task($io)
+        end
+        Threads.@spawn _prefetching_task($io)
         return io
     end
 
@@ -151,20 +212,20 @@ Base.isopen(io::PrefechedDownloadStream) = !eof(io)
 function getbuffer(io::PrefechedDownloadStream)
     buf = io.buf
     if isnothing(buf)
-        buf = take!(io.queue)
+        buf = take!(io.prefetch_queue)
         io.buf = buf
     end
     return buf
 end
 
 function _unsafe_read(io::PrefechedDownloadStream, dest::Ptr{UInt8}, bytes_to_read::Int)
-    bytes_read = 1
+    bytes_read = 0
     while bytes_to_read > bytes_read
         buf = getbuffer(io)::PrefetchBuffer
         bytes_in_buffer = bytesavailable(buf)
 
-        adv = min(bytes_in_buffer, bytes_to_read - bytes_read + 1)
-        GC.@preserve buf unsafe_copyto!(dest + bytes_read - 1, pointer(buf.data) + buf.pos - 1, adv)
+        adv = min(bytes_in_buffer, bytes_to_read - bytes_read)
+        GC.@preserve buf unsafe_copyto!(dest + bytes_read, pointer(buf.data, buf.pos), adv)
         buf.pos += adv
         bytes_read += adv
         io.pos += adv
@@ -173,7 +234,7 @@ function _unsafe_read(io::PrefechedDownloadStream, dest::Ptr{UInt8}, bytes_to_re
             io.buf = nothing
         end
     end
-    return bytes_read - 1
+    return bytes_read
 end
 
 function Base.readbytes!(io::PrefechedDownloadStream, dest::AbstractVector{UInt8}, n)

--- a/src/object.jl
+++ b/src/object.jl
@@ -87,3 +87,110 @@ function Base.readbytes!(x::IOObject, dest::AbstractVector{UInt8}, n::Integer=le
     end
     return dest
 end
+
+mutable struct PrefetchBuffer
+    data::Vector{UInt8}
+    pos::Int
+    len::Int
+end
+Base.bytesavailable(b::PrefetchBuffer) = b.len - b.pos + 1
+
+function _prefetching_task(io)
+    prefetch_size = io.prefetch_size
+    len = io.len
+    object = io.object
+    ppos = 1
+
+    while len > ppos
+        n = min(bytesavailable(io), prefetch_size)
+        buf = PrefetchBuffer(getRange(object, ppos, n), 1, n)
+        ppos += n
+        # unbuffered, blocks until we're done with the previous buffer and `take!` the next one
+        put!(io.queue, buf)
+    end
+    close(io.queue)
+    return nothing
+end
+
+mutable struct PrefechedDownloadStream{T <: Object} <: IO
+    object::T
+    pos::Int
+    len::Int
+    buf::Union{Nothing,PrefetchBuffer}
+    prefetch_size::Int
+    queue::Channel{PrefetchBuffer}
+
+    function PrefechedDownloadStream(
+        object::T,
+        prefetch_size::Int=MULTIPART_SIZE;
+    ) where {T<:Object}
+        len = length(object)
+        size = min(prefetch_size, len)
+        io = new{T}(object, 1, len, nothing, size, Channel{PrefetchBuffer}(0))
+        Threads.@spawn _prefetching_task(io)
+        return io
+    end
+
+    function PrefechedDownloadStream(
+        store::AbstractStore,
+        key::String,
+        prefetch_size::Int=MULTIPART_SIZE;
+        credentials::Union{CloudCredentials, Nothing}=nothing
+    )
+        url = makeURL(store, key)
+        resp = API.headObject(store, url, HTTP.Headers(); credentials=credentials)
+        len = parse(Int, HTTP.header(resp, "Content-Length", "0"))
+        et = etag(HTTP.header(resp, "ETag", ""))
+        object = Object(store, credentials, String(key), Int(len), String(et))
+        return PrefechedDownloadStream(object, prefetch_size)
+    end
+end
+Base.eof(io::PrefechedDownloadStream) = io.pos >= io.len
+Base.bytesavailable(io::PrefechedDownloadStream) = io.len - io.pos + 1
+Base.isopen(io::PrefechedDownloadStream) = !eof(io)
+function getbuffer(io::PrefechedDownloadStream)
+    buf = io.buf
+    if isnothing(buf)
+        buf = take!(io.queue)
+        io.buf = buf
+    end
+    return buf
+end
+
+function _unsafe_read(io::PrefechedDownloadStream, dest::Ptr{UInt8}, bytes_to_read::Int)
+    bytes_read = 1
+    while bytes_to_read > bytes_read
+        buf = getbuffer(io)::PrefetchBuffer
+        bytes_in_buffer = bytesavailable(buf)
+
+        adv = min(bytes_in_buffer, bytes_to_read - bytes_read + 1)
+        GC.@preserve buf unsafe_copyto!(dest + bytes_read - 1, pointer(buf.data) + buf.pos - 1, adv)
+        buf.pos += adv
+        bytes_read += adv
+        io.pos += adv
+
+        if buf.pos > buf.len
+            io.buf = nothing
+        end
+    end
+    return bytes_read - 1
+end
+
+function Base.readbytes!(io::PrefechedDownloadStream, dest::AbstractVector{UInt8}, n)
+    eof(io) && return UInt32(0)
+    bytes_to_read = min(bytesavailable(io), Int(n))
+    bytes_to_read > length(dest) && resize!(dest, bytes_to_read)
+    bytes_read = GC.@preserve dest _unsafe_read(io, pointer(dest), bytes_to_read)
+    return UInt32(bytes_read)
+end
+
+function Base.unsafe_read(io::PrefechedDownloadStream, p::Ptr{UInt8}, nb::UInt)
+    if eof(io)
+        nb > 0 && throw(EOFError())
+        return nothing
+    end
+    avail = bytesavailable(io)
+    _unsafe_read(io, p, min(avail, Int(nb)))
+    nb > avail && throw(EOFError())
+    return nothing
+end

--- a/src/object.jl
+++ b/src/object.jl
@@ -103,14 +103,14 @@ Base.bytesavailable(b::PrefetchBuffer) = b.len - b.pos + 1
 function _prefetching_task(io)
     prefetch_size = io.prefetch_size
     len = io.len
-    ppos = 1
+    ppos = 0
     download_buffer = Vector{UInt8}(undef, prefetch_size)
     download_buffer_next = Vector{UInt8}(undef, prefetch_size)
 
     while len > ppos
         n = min(len - ppos + 1, prefetch_size)
         off = 0
-        rngs = Iterators.partition(ppos:ppos+n-1, 2*1024*1024)
+        rngs = Iterators.partition(ppos:ppos+n 2*1024*1024)
         io.cond.ntasks = length(rngs)
         # @info "expect $(io.cond.ntasks)"
         for rng in rngs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test, CloudStore, CloudBase.CloudTest
 import CloudStore: S3, Blobs
+using CodecZlib
 
 bytes(x) = codeunits(x)
 
@@ -118,7 +119,7 @@ check(x, y) = begin; reset!(x); reset!(y); z = read(x) == read(y); reset!(x); re
                 S3.delete(bucket, "test4.csv"; credentials)
                 S3.delete(bucket, "test5.csv"; credentials)
                 S3.delete(bucket, "test6.csv"; credentials)
-                
+
                 objs = S3.list(bucket; credentials)
                 @test length(objs) == 0
             end
@@ -266,7 +267,7 @@ end
 @testset "CloudStore.Object API" begin
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
-        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^100000; # 2MB
         S3.put(bucket, "test.csv", codeunits(multicsv); credentials)
         obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)
@@ -276,10 +277,158 @@ end
 
         ioobj = CloudStore.IOObject(obj)
         i = 1
-        while !eof(ioobj)
+        while i < sizeof(multicsv)
             readbytes!(ioobj, buf, 1000)
             @test buf == view(codeunits(multicsv), i:min(i+999, length(multicsv)))
             i += 1000
+        end
+    end
+end
+
+@testset "CloudStore.PrefechedDownloadStream small readbytes!" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^10; # 200 B
+        S3.put(bucket, "test.csv", codeunits(multicsv); credentials)
+        obj = CloudStore.Object(bucket, "test.csv"; credentials)
+        @test length(obj) == sizeof(multicsv)
+
+        N = 19
+        buf = Vector{UInt8}(undef, N)
+        copyto!(buf, 1, obj, 1, N)
+        @test buf == view(codeunits(multicsv), 1:N)
+
+        ioobj = CloudStore.PrefechedDownloadStream(bucket, "test.csv", 16; credentials)
+        i = 1
+        while i < sizeof(multicsv)
+            nb = i + N > length(multicsv) ? length(multicsv) - i : N
+            readbytes!(ioobj, buf, N)
+            @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
+            i += N
+        end
+    end
+end
+
+@testset "CloudStore.PrefechedDownloadStream large readbytes!" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20 MB
+        S3.put(bucket, "test.csv", codeunits(multicsv); credentials)
+        obj = CloudStore.Object(bucket, "test.csv"; credentials)
+        @test length(obj) == sizeof(multicsv)
+
+        N = 1024*1024
+        buf = Vector{UInt8}(undef, N)
+        copyto!(buf, 1, obj, 1, N)
+        @test buf == view(codeunits(multicsv), 1:N)
+
+        ioobj = CloudStore.PrefechedDownloadStream(bucket, "test.csv", 1024*1024; credentials)
+        i = 1
+        while i < sizeof(multicsv)
+            nb = i + N > length(multicsv) ? length(multicsv) - i : N
+            readbytes!(ioobj, buf, N)
+            @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
+            i += N
+        end
+    end
+end
+
+@testset "CloudStore.PrefechedDownloadStream small unsafe_read" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^10; # 200 B
+        S3.put(bucket, "test.csv", codeunits(multicsv); credentials)
+        obj = CloudStore.Object(bucket, "test.csv"; credentials)
+        @test length(obj) == sizeof(multicsv)
+
+        N = 19
+        buf = Vector{UInt8}(undef, N)
+        copyto!(buf, 1, obj, 1, N)
+        @test buf == view(codeunits(multicsv), 1:N)
+
+        ioobj = CloudStore.PrefechedDownloadStream(bucket, "test.csv", 16; credentials)
+        i = 1
+        @time while i < sizeof(multicsv)
+            nb = i + N > length(multicsv) ? length(multicsv) - i : N
+            unsafe_read(ioobj, pointer(buf), nb)
+            @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
+            i += N
+        end
+    end
+end
+
+@testset "CloudStore.PrefechedDownloadStream large unsafe_read" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20 MB
+        S3.put(bucket, "test.csv", codeunits(multicsv); credentials)
+        obj = CloudStore.Object(bucket, "test.csv"; credentials)
+        @test length(obj) == sizeof(multicsv)
+
+        N = 1024*1024
+        buf = Vector{UInt8}(undef, N)
+        copyto!(buf, 1, obj, 1, N)
+        @test buf == view(codeunits(multicsv), 1:N)
+
+        ioobj = CloudStore.PrefechedDownloadStream(bucket, "test.csv", 1024*1024; credentials)
+        i = 1
+        while i < sizeof(multicsv)
+            nb = i + N > length(multicsv) ? length(multicsv) - i : N
+            unsafe_read(ioobj, pointer(buf), nb)
+            @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
+            i += N
+        end
+    end
+end
+
+
+
+@testset "CloudStore.PrefechedDownloadStream small readbytes! decompress" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^100; # 2000 B
+        codec = ZlibCompressor();
+        CodecZlib.initialize(codec)
+        compressed = transcode(codec, codeunits(multicsv))
+        S3.put(bucket, "test.csv.gz", compressed; credentials)
+        CodecZlib.finalize(codec)
+        obj = CloudStore.Object(bucket, "test.csv.gz"; credentials)
+        @test length(obj) == sizeof(compressed)
+
+        N = 19
+        buf = Vector{UInt8}(undef, N)
+        ioobj = GzipDecompressorStream(CloudStore.PrefechedDownloadStream(bucket, "test.csv.gz", 16; credentials))
+        i = 1
+        while i < sizeof(multicsv)
+            nb = i + N > length(multicsv) ? length(multicsv) - i : N
+            readbytes!(ioobj, buf, N)
+            @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
+            i += N
+        end
+    end
+end
+
+@testset "CloudStore.PrefechedDownloadStream large readbytes! decompress" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20 MB
+        codec = ZlibCompressor();
+        CodecZlib.initialize(codec)
+        compressed = transcode(codec, codeunits(multicsv))
+        S3.put(bucket, "test.csv.gz", compressed; credentials)
+        CodecZlib.finalize(codec)
+        obj = CloudStore.Object(bucket, "test.csv.gz"; credentials)
+        @test length(obj) == sizeof(compressed)
+
+        N = 1024*1024
+        buf = Vector{UInt8}(undef, N)
+        ioobj = GzipDecompressorStream(CloudStore.PrefechedDownloadStream(bucket, "test.csv.gz", 16*1024; credentials))
+        i = 1
+        while i < sizeof(multicsv)
+            nb = i + N > length(multicsv) ? length(multicsv) - i : N
+            readbytes!(ioobj, buf, N)
+            @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
+            i += N
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -264,27 +264,6 @@ end
     end
 end
 
-@testset "CloudStore.Object API" begin
-    Minio.with(; debug=true) do conf
-        credentials, bucket = conf
-        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^100000; # 2MB
-        S3.put(bucket, "test.csv", codeunits(multicsv); credentials)
-        obj = CloudStore.Object(bucket, "test.csv"; credentials)
-        @test length(obj) == sizeof(multicsv)
-        buf = Vector{UInt8}(undef, 1000)
-        copyto!(buf, 1, obj, 1, 1000)
-        @test buf == view(codeunits(multicsv), 1:1000)
-
-        ioobj = CloudStore.IOObject(obj)
-        i = 1
-        while i < sizeof(multicsv)
-            readbytes!(ioobj, buf, 1000)
-            @test buf == view(codeunits(multicsv), i:min(i+999, length(multicsv)))
-            i += 1000
-        end
-    end
-end
-
 @testset "CloudStore.PrefechedDownloadStream small readbytes!" begin
     Minio.with(; debug=true) do conf
         credentials, bucket = conf

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,8 @@ check(x::String, y::AbstractVector{UInt8}) = read(x) == y
 check(x::IO, y::AbstractVector{UInt8}) = begin; reset!(x); z = read(x) == y; reset!(x); z end
 check(x, y) = begin; reset!(x); reset!(y); z = read(x) == read(y); reset!(x); reset!(y); z end
 
-@time @testset "S3" begin
+@testset "CloudStore.jl" begin
+@testset "S3" begin
     # conf, p = Minio.run(; debug=true)
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
@@ -411,3 +412,4 @@ end
         end
     end
 end
+end # @testset "CloudStore.jl"


### PR DESCRIPTION
An idea; didn't really profile it (yet!). We use a single task for the entire lifetime of the `Object` and we're compatible with `GzipDecompressorStream` to support compression.