### PR TITLE
Handle redirects even when using the inner constructor of Object

### DIFF
--- a/src/get.jl
+++ b/src/get.jl
@@ -55,6 +55,7 @@ function getObjectImpl(x::AbstractStore, key::String, out::ResponseBodyType=noth
         # make a head request to see if the object happens to be empty
         # if so, it isn't valid to make a Range bytes request, so we'll short-circuit
         resp = API.headObject(x, url, headers; kw...)
+        # The ArgumentError will be caused by the HTTP error to provide more context
         if HTTP.isredirect(resp)
             try
                 throw(HTTP.StatusError(resp.status, resp.request.method, resp.request.target, resp))

--- a/src/object.jl
+++ b/src/object.jl
@@ -196,6 +196,13 @@ mutable struct PrefetchedDownloadStream{T <: Object} <: IO
     )
         url = makeURL(store, key)
         resp = API.headObject(store, url, HTTP.Headers(); credentials=credentials)
+        if HTTP.isredirect(resp)
+            try
+                throw(HTTP.StatusError(resp.status, resp.request.method, resp.request.target, resp))
+            catch
+                throw(ArgumentError("Invalid object key: $key"))
+            end
+        end
         len = parse(Int, HTTP.header(resp, "Content-Length", "0"))
         et = etag(HTTP.header(resp, "ETag", ""))
         object = Object(store, credentials, String(key), Int(len), String(et))

--- a/src/object.jl
+++ b/src/object.jl
@@ -21,6 +21,7 @@ Object(
 function Object(store::AbstractStore, key::String; credentials::Union{CloudCredentials, Nothing}=nothing)
     url = makeURL(store, key)
     resp = API.headObject(store, url, HTTP.Headers(); credentials=credentials)
+    # The ArgumentError will be caused by the HTTP error to provide more context
     if HTTP.isredirect(resp)
         try
             throw(HTTP.StatusError(resp.status, resp.request.method, resp.request.target, resp))
@@ -196,6 +197,7 @@ mutable struct PrefetchedDownloadStream{T <: Object} <: IO
     )
         url = makeURL(store, key)
         resp = API.headObject(store, url, HTTP.Headers(); credentials=credentials)
+        # The ArgumentError will be caused by the HTTP error to provide more context
         if HTTP.isredirect(resp)
             try
                 throw(HTTP.StatusError(resp.status, resp.request.method, resp.request.target, resp))


### PR DESCRIPTION
MIssed this codepath in the previous [commit](https://github.com/JuliaServices/CloudStore.jl/pull/29#issue-1536671035).