### PR TITLE
Don't parse local urls by default unless explicitly requested

### DIFF
--- a/src/blobs.jl
+++ b/src/blobs.jl
@@ -60,8 +60,8 @@ delete(x::Container, key::String; kw...) = Azure.delete(API.makeURL(x, key); kw.
 delete(x::Object; kw...) = delete(x.store, x.key; credentials=x.credentials, kw...)
 
 for func in (:list, :get, :head, :put, :delete)
-    @eval function $func(url::AbstractString, args...; kw...)
-        ok, host, account, container, blob = parseAzureAccountContainerBlob(url; parseLocal=true)
+    @eval function $func(url::AbstractString, args...; parseLocal::Bool=false, kw...)
+        ok, host, account, container, blob = parseAzureAccountContainerBlob(url; parseLocal=parseLocal)
         ok || throw(ArgumentError("invalid url for Blobs.$($func): `$url`"))
         if blob !== nothing
             return $func(Azure.Container(container, account; host), blob, args...; kw...)

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -61,8 +61,8 @@ delete(x::Bucket, key; kw...) = AWS.delete(API.makeURL(x, key); service="s3", kw
 delete(x::Object; kw...) = delete(x.store, x.key; credentials=x.credentials, kw...)
 
 for func in (:list, :get, :head, :put, :delete)
-    @eval function $func(url::AbstractString, args...; region=nothing, nowarn::Bool=false, kw...)
-        ok, accelerate, host, bucket, reg, key = parseAWSBucketRegionKey(url; parseLocal=true)
+    @eval function $func(url::AbstractString, args...; region=nothing, nowarn::Bool=false, parseLocal::Bool=false, kw...)
+        ok, accelerate, host, bucket, reg, key = parseAWSBucketRegionKey(url; parseLocal=parseLocal)
         ok || throw(ArgumentError("invalid url for S3.$($func): `$url`"))
         if region === nothing
             nowarn || @warn "`region` keyword argument not provided to `S3.$($func)` and undetected from url.  Defaulting to `us-east-1`"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,8 +79,8 @@ check(x, y) = begin; reset!(x); reset!(y); z = read(x) == read(y); reset!(x); re
 
                 # passing urls directly
                 url = "$(bucket.baseurl)test5.csv"
-                obj = S3.put(url, body; credentials)
-                data = S3.get(url, out; credentials)
+                obj = S3.put(url, body; parseLocal=true, credentials)
+                data = S3.get(url, out; parseLocal=true, credentials)
                 @test check(body, data)
                 resetOut!(out)
                 cleanup!(body)
@@ -165,8 +165,8 @@ end
 
                 # passing urls directly
                 url = "$(container.baseurl)test5.csv"
-                obj = Blobs.put(url, body; credentials)
-                data = Blobs.get(url, out; credentials)
+                obj = Blobs.put(url, body; parseLocal=true, credentials)
+                data = Blobs.get(url, out; parseLocal=true, credentials)
                 @test check(body, data)
                 resetOut!(out)
                 cleanup!(body)


### PR DESCRIPTION
This avoids scenarios where you may unintentionally allow a user to pass a local IP address and it parses and tries to make a request where local parsing is really meant as a test-only feature.