### PR TITLE
Summary of changes:

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,15 +7,19 @@ version = "1.3.9"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CloudBase = "85eb1798-d7c4-4918-bb13-c944d38e27ed"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+CodecZlibNG = "642d12eb-acb5-4437-bcfc-a25e07ad685c"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 WorkerUtilities = "76eceee3-57b5-4d4a-8e66-0e911cebbf60"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
 CloudBase = "1"
 CodecZlib = "0.7"
-HTTP = "1"
+CodecZlibNG = "0.1"
+HTTP = "1.7"
+TranscodingStreams = "0.9.12"
 WorkerUtilities = "1.1"
 XMLDict = "0.4"
 julia = "1.6"
@@ -23,7 +27,6 @@ julia = "1.6"
 [extras]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
 
 [targets]
 test = ["CodecZlib", "Test"]

--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -8,7 +8,7 @@ module API
 
 export Object, PrefetchedDownloadStream, ResponseBodyType, RequestBodyType
 
-using HTTP, CodecZlib, Mmap
+using HTTP, CodecZlib, CodecZlibNG, Mmap
 import WorkerUtilities: OrderedSynchronizer
 import CloudBase: AbstractStore
 
@@ -21,7 +21,7 @@ const MULTIPART_SIZE = 2^23
 
 defaultBatchSize() = 4 * Threads.nthreads()
 
-const ResponseBodyType = Union{Nothing, String, IO}
+const ResponseBodyType = Union{Nothing, AbstractVector{UInt8}, String, IO}
 const RequestBodyType = Union{AbstractVector{UInt8}, String, IO}
 
 asArray(x::Array) = x


### PR DESCRIPTION
Summary of changes:
* When we perform the HEAD request, and the output type is a buffer, we know what the final size should be, so
    allocate the final buffer up front
* We then pass "views" of that buffer to HTTP according to the specific Content-Range that a given task is requesting,
    this further avoids unnecessary allocations by having each HTTP request write directly to the slice of the final
    buffer it is responsible for
* Also added a debug message that will log the overal bit-rate achieved while downloading; useful for benchmarking
* Support passing in a pre-allocated byte buffer that will be used directly when writing the response body
* Allow passing keyword arg zlibng=true to use CodecZlibNG instead of CodecZlib for compression/decompression