### PR TITLE
Use the http protocol (instead of https) when connecting to Azurite

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -84,7 +84,7 @@ end
 function _validate_azure(ok::Bool, host, account, container, blob)
     return (
         ok,
-        isnothing(host) ? nothing : replace(String(host), r"^azure"i => "https"; count=1),
+        isnothing(host) ? nothing : replace(String(host), r"^azure"i => "http"; count=1),
         String(validate_account_name(account)),
         isnothing(container) ? "" : String(validate_container_name(container)),
         isnothing(blob) ? "" : String(validate_blob(blob)),

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -84,6 +84,7 @@ end
 function _validate_azure(ok::Bool, host, account, container, blob)
     return (
         ok,
+        # We only replace the host when parseLocal is true
         isnothing(host) ? nothing : replace(String(host), r"^azure"i => "http"; count=1),
         String(validate_account_name(account)),
         isnothing(container) ? "" : String(validate_container_name(container)),
@@ -95,6 +96,7 @@ function _validate_aws(ok::Bool, accelerate, host, bucket, region, key)
     return (
         ok,
         accelerate,
+        # We only replace the host when parseLocal is true
         isnothing(host) ? nothing : replace(String(host), r"^(s|S)3" => "http"; count=1),
         String(validate_bucket_name(bucket, accelerate)),
         isnothing(region) || isempty(region) ? "" : String(validate_region(region)),

--- a/test.csv
+++ b/test.csv
@@ -1,1 +1,0 @@
-s;kjgndlfkgjbdfkjnbdlkfjgnb;ekjnbwr;kthmwrl;hkmq'rlkthm'rlkthnq'thnmq'egkmq'l

--- a/test.csv
+++ b/test.csv
@@ -1,0 +1,1 @@
+s;kjgndlfkgjbdfkjnbdlkfjgnb;ekjnbwr;kthmwrl;hkmq'rlkthm'rlkthnq'thnmq'egkmq'l

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,8 +238,8 @@ end
         ("azure://myaccount.blob.core.windows.net/mycontainer", (true, nothing, "myaccount", "mycontainer", "")),
         ("https://127.0.0.1:45942/myaccount/mycontainer", (true, "https://127.0.0.1:45942", "myaccount", "mycontainer", "")),
         ("https://127.0.0.1:45942/myaccount/mycontainer/myblob", (true, "https://127.0.0.1:45942", "myaccount", "mycontainer", "myblob")),
-        ("azure://127.0.0.1:45942/myaccount/mycontainer", (true, "https://127.0.0.1:45942", "myaccount", "mycontainer", "")),
-        ("azure://127.0.0.1:45942/myaccount/mycontainer/myblob", (true, "https://127.0.0.1:45942", "myaccount", "mycontainer", "myblob")),
+        ("azure://127.0.0.1:45942/myaccount/mycontainer", (true, "http://127.0.0.1:45942", "myaccount", "mycontainer", "")),
+        ("azure://127.0.0.1:45942/myaccount/mycontainer/myblob", (true, "http://127.0.0.1:45942", "myaccount", "mycontainer", "myblob")),
         ("azure://myaccount", (true, nothing, "myaccount", "", "")),
 
         ("HTTPS://myaccount.BLOB.core.windows.net/mycontainer/myblob", (true, nothing, "myaccount", "mycontainer", "myblob")),
@@ -248,8 +248,8 @@ end
         ("azurE://myaccount.blob.core.windows.NET/mycontainer", (true, nothing, "myaccount", "mycontainer", "")),
         ("Https://127.0.0.1:45942/myaccount/mycontainer", (true, "Https://127.0.0.1:45942", "myaccount", "mycontainer", "")),
         ("hTTPs://127.0.0.1:45942/myaccount/mycontainer/myblob", (true, "hTTPs://127.0.0.1:45942", "myaccount", "mycontainer", "myblob")),
-        ("Azure://127.0.0.1:45942/myaccount/mycontainer", (true, "https://127.0.0.1:45942", "myaccount", "mycontainer", "")),
-        ("aZURe://127.0.0.1:45942/myaccount/mycontainer/myblob", (true, "https://127.0.0.1:45942", "myaccount", "mycontainer", "myblob")),
+        ("Azure://127.0.0.1:45942/myaccount/mycontainer", (true, "http://127.0.0.1:45942", "myaccount", "mycontainer", "")),
+        ("aZURe://127.0.0.1:45942/myaccount/mycontainer/myblob", (true, "http://127.0.0.1:45942", "myaccount", "mycontainer", "myblob")),
         ("Azure://myaccount", (true, nothing, "myaccount", "", ""))
     ]
     for (url, parts) in azure


### PR DESCRIPTION
When using the https protocol to connect to Azurite, DuckDB rejects the connection due to the invalid remote SSL certificate. Replace the protocol for azure:// with http://, it is compatible with both Julia's CloudBase/CloudStore and DuckDB and it is only used for testing with Azurite.