### PR TITLE
Add a MultipartUploadStream IO object

### DIFF
--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -6,7 +6,8 @@ import CloudBase: AWS, Azure, CloudTest
 # for specific clouds
 module API
 
-export Object, PrefetchedDownloadStream, ResponseBodyType, RequestBodyType
+export Object, PrefetchedDownloadStream, ResponseBodyType, RequestBodyType,
+    MultipartUploadStream
 
 using HTTP, CodecZlib, CodecZlibNG, Mmap
 import WorkerUtilities: OrderedSynchronizer

--- a/src/object.jl
+++ b/src/object.jl
@@ -410,6 +410,8 @@ For every data chunk we call write(io, data;) to write it to a channel. We spawn
 per chunk to read data from this channel and uploads it as a distinct part to blob storage
 to the same remote object.
 We expect the chunks to be written in order.
+For cases where there is no need to upload data in parts or the data size is too small, `put`
+can be used instead.
 
 # Arguments
 * `store::AbstractStore`: The S3 Bucket / Azure Container object
@@ -445,22 +447,13 @@ MultipartUploadStream(bucket, "test.csv"; credentials) do io
 end
 ```
 
-## Performance
-```
-We have benchmarked the performance of `MultipartUploadStream` for smaller (~39MB) and larger
-files up to ~860MB. For smaller files the performance is similar to an S3.put call, whereas
-for larger ones we do see a degradation of about 18% after ~300MB, that is growing more as
-the size of the uploaded file grows. We need to investirage further the cause of this.
-Some benchmark results can be found in https://github.com/JuliaServices/CloudStore.jl/pull/46#issuecomment-1804298709
-and https://github.com/JuliaServices/CloudStore.jl/pull/46#issuecomment-1810558208.
-```
-
 ## Note on upload size
 ```
 Some cloud storage providers might have a lower limit on the size of the uploaded object.
 For example it seems that S3 requires at minimum an upload of 5MB:
 https://github.com/minio/minio/issues/11076.
 We haven't found a similar setting for Azure.
+For such cases where the size of the data is too small, one can use `put`
 ```
 """
 mutable struct MultipartUploadStream{T <: AbstractStore} <: IO

--- a/src/object.jl
+++ b/src/object.jl
@@ -494,7 +494,7 @@ function Base.write(io::MultipartUploadStream, bytes::Vector{UInt8}; kw...)
     Threads.@spawn _upload_task(io, part_n; kw...)
     # atomically increment our part counter
     @static if VERSION < v"1.7"
-        io.cur_part_id[] += 1
+        Threads.atomic_add!(io.cur_part_id, 1)
     else
         @atomic io.cur_part_id += 1
     end

--- a/src/object.jl
+++ b/src/object.jl
@@ -306,13 +306,11 @@ end
 
 function Base.write(x::MultipartUploadStream, bytes::Vector{UInt8}; kw...)
     # upload the part
-    @show x.cur_part_id
     parteTag, wb = uploadPart(x.store, x.url, bytes, x.cur_part_id, x.uploadState; x.credentials, kw...)
     # add part eTag to our collection of eTags in the right order
     put!(x.sync, x.cur_part_id) do
         push!(x.eTags, parteTag)
     end
-    @show x.eTags
     # atomically increment our part counter
     @atomic x.cur_part_id += 1
     return wb

--- a/src/object.jl
+++ b/src/object.jl
@@ -494,7 +494,7 @@ function Base.write(io::MultipartUploadStream, bytes::Vector{UInt8}; kw...)
     Threads.@spawn _upload_task(io, part_n; kw...)
     # atomically increment our part counter
     @static if VERSION < v"1.7"
-        io.cur_part_id += 1
+        io.cur_part_id[] += 1
     else
         @atomic io.cur_part_id += 1
     end

--- a/src/object.jl
+++ b/src/object.jl
@@ -106,7 +106,6 @@ function _prefetching_task(io)
             download_buffer, download_buffer_next = download_buffer_next, download_buffer
         end
     catch e
-        @show "This path is exercised in tests!"
         isopen(io.download_queue) && close(io.download_queue, e)
         isopen(io.prefetch_queue) && close(io.prefetch_queue, e)
         rethrow()

--- a/src/object.jl
+++ b/src/object.jl
@@ -458,7 +458,7 @@ end
                 uploadState,
                 OrderedSynchronizer(1),
                 Vector{String}(),
-                Threads.Atomic{Bool}(1),
+                Threads.Atomic{Int}(1),
                 Channel{Vector{UInt8}}(Inf),
                 Threads.Condition(),
                 0,

--- a/src/object.jl
+++ b/src/object.jl
@@ -449,20 +449,38 @@ end
     )
         url = makeURL(store, key)
         uploadState = API.startMultipartUpload(store, key; credentials, kw...)
-        return new(
-            store,
-            key,
-            url,
-            credentials,
-            uploadState,
-            OrderedSynchronizer(1),
-            Vector{String}(),
-            1,
-            Channel{Vector{UInt8}}(Inf),
-            Threads.Condition(),
-            0,
-            false,
-        )
+        @static if VERSION < v"1.7"
+            io = new(
+                store,
+                key,
+                url,
+                credentials,
+                uploadState,
+                OrderedSynchronizer(1),
+                Vector{String}(),
+                Threads.Atomic{Bool}(1),
+                Channel{Vector{UInt8}}(Inf),
+                Threads.Condition(),
+                0,
+                false,
+            )
+        else
+            io = new(
+                store,
+                key,
+                url,
+                credentials,
+                uploadState,
+                OrderedSynchronizer(1),
+                Vector{String}(),
+                1,
+                Channel{Vector{UInt8}}(Inf),
+                Threads.Condition(),
+                0,
+                false,
+            )
+        end
+        return io
     end
 end
 

--- a/src/object.jl
+++ b/src/object.jl
@@ -508,6 +508,11 @@ end
 
 
 function Base.close(io::MultipartUploadStream; kw...)
-    close(io.upload_queue)
-    return API.completeMultipartUpload(io.store, io.url, io.eTags, io.uploadState; kw...)
+    try
+        close(io.upload_queue)
+        return API.completeMultipartUpload(io.store, io.url, io.eTags, io.uploadState; kw...)
+    catch e
+        io.exc = e
+        rethrow()
+    end
 end

--- a/src/object.jl
+++ b/src/object.jl
@@ -274,7 +274,6 @@ mutable struct PrefetchedDownloadStream{T <: Object} <: IO
         return PrefetchedDownloadStream(object, prefetch_size; prefetch_multipart_size, kw...)
     end
 end
-
 Base.eof(io::PrefetchedDownloadStream) = io.pos > io.len
 bytesremaining(io::PrefetchedDownloadStream) = io.len - io.pos + 1
 function Base.bytesavailable(io::PrefetchedDownloadStream)

--- a/src/object.jl
+++ b/src/object.jl
@@ -475,9 +475,9 @@ function Base.write(io::MultipartUploadStream, bytes::Vector{UInt8}; kw...)
         part_n = io.cur_part_id
         notify(io.cond_wait)
     end
-    Base.acquire(io.sem) do
-        put!(io.upload_queue, (part_n, bytes))
-    end
+    Base.acquire(io.sem)
+    put!(io.upload_queue, (part_n, bytes))
+    Base.release(io.sem)
     Threads.@spawn _upload_task($io; $(kw)...)
     return nothing
 end

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -48,6 +48,7 @@ end
 
 function API.uploadPart(x::Bucket, url, part, partNumber, uploadId; kw...)
     resp = AWS.put(url, [], part; query=Dict("partNumber" => string(partNumber), "uploadId" => uploadId), service="s3", kw...)
+    @show resp
     return (HTTP.header(resp, "ETag"), Base.get(resp.request.context, :nbytes_written, 0))
 end
 

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -48,15 +48,12 @@ end
 
 function API.uploadPart(x::Bucket, url, part, partNumber, uploadId; kw...)
     resp = AWS.put(url, [], part; query=Dict("partNumber" => string(partNumber), "uploadId" => uploadId), service="s3", kw...)
-    @show resp
     return (HTTP.header(resp, "ETag"), Base.get(resp.request.context, :nbytes_written, 0))
 end
 
 function API.completeMultipartUpload(x::Bucket, url, eTags, uploadId; kw...)
-    @show "complete multipart upload"
     body = XMLDict.node_xml("CompleteMultipartUpload", Dict("Part" => [Dict("PartNumber" => string(i), "ETag" => eTag) for (i, eTag) in enumerate(eTags)]))
     resp = AWS.post(url; query=Dict("uploadId" => uploadId), body, service="s3", kw...)
-    @show "after complete upload"
     return API.etag(HTTP.header(resp, "ETag"))
 end
 

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -52,8 +52,10 @@ function API.uploadPart(x::Bucket, url, part, partNumber, uploadId; kw...)
 end
 
 function API.completeMultipartUpload(x::Bucket, url, eTags, uploadId; kw...)
+    @show "complete multipart upload"
     body = XMLDict.node_xml("CompleteMultipartUpload", Dict("Part" => [Dict("PartNumber" => string(i), "ETag" => eTag) for (i, eTag) in enumerate(eTags)]))
     resp = AWS.post(url; query=Dict("uploadId" => uploadId), body, service="s3", kw...)
+    @show "after complete upload"
     return API.etag(HTTP.header(resp, "ETag"))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -793,7 +793,7 @@ end
     end
 end=#
 
-#=@testset "CloudStore.MultipartUploadStream write large bytes - S3" begin
+@testset "CloudStore.MultipartUploadStream write large bytes - S3" begin
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
         multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
@@ -808,15 +808,15 @@ end=#
             @show typeof(codeunits(multicsv))
             copyto!(buf, 1, codeunits(multicsv), i, nb)
             @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
-            #CloudStore.write(mus_obj, buf;)
+            CloudStore.write(mus_obj, buf;)
             i += N
         end
 
-        #CloudStore.close(mus_obj; credentials)
+        CloudStore.close(mus_obj; credentials)
         obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)
     end
-end=#
+end
 
 @testset "CloudStore.MultipartUploadStream write large bytes - Azure" begin
     Azurite.with(; debug=true) do conf
@@ -827,14 +827,14 @@ end=#
         mus_obj = CloudStore.MultipartUploadStream(bucket, "test.csv"; credentials)
 
         i = 1
-        #while i < sizeof(multicsv)
+        while i < sizeof(multicsv)
             nb = i + N > length(multicsv) ? length(multicsv)-i+1 : N
             buf = Vector{UInt8}(undef, nb)
             copyto!(buf, 1, codeunits(multicsv), i, nb)
             @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
             CloudStore.write(mus_obj, buf;)
             i += N
-        #end
+        end
 
         CloudStore.close(mus_obj; credentials)
         obj = CloudStore.Object(bucket, "test.csv"; credentials)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -887,4 +887,30 @@ end
     end
 end
 
+@testset "CloudStore.MultipartUploadStream test alternative syntax - Azure" begin
+    Azurite.with(; debug=true) do conf
+        credentials, bucket = conf
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
+
+        N = 2000000
+        function uploading_loop(multicsv, batch_size, mus_obj)
+            i = 1
+            while i < sizeof(multicsv)
+                nb = i + batch_size > length(multicsv) ? length(multicsv)-i+1 : batch_size
+                buf = Vector{UInt8}(undef, nb)
+                copyto!(buf, 1, codeunits(multicsv), i, nb)
+                CloudStore.write(mus_obj, buf;)
+                i += batch_size
+            end
+        end
+
+       CloudStore.MultipartUploadStream(bucket, "test.csv"; credentials) do mus_obj
+            uploading_loop(multicsv, N, mus_obj)
+        end
+
+        obj = CloudStore.Object(bucket, "test.csv"; credentials)
+        @test length(obj) == sizeof(multicsv)
+    end
+end
+
 end # @testset "CloudStore.jl"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -805,7 +805,6 @@ end=#
         while i < sizeof(multicsv)
             nb = i + N > length(multicsv) ? length(multicsv)-i+1 : N
             buf = Vector{UInt8}(undef, nb)
-            @show typeof(codeunits(multicsv))
             copyto!(buf, 1, codeunits(multicsv), i, nb)
             @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
             CloudStore.write(mus_obj, buf;)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -793,9 +793,9 @@ end
     end
 end=#
 
-@testset "CloudStore.MultipartUploadStream write large bytes - S3" begin
-    ((credentials, bucket), proc) = Minio.run(; debug=true)
-        #credentials, bucket = conf
+#=@testset "CloudStore.MultipartUploadStream write large bytes - S3" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
         multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
 
         N = 5500000
@@ -808,15 +808,15 @@ end=#
             @show typeof(codeunits(multicsv))
             copyto!(buf, 1, codeunits(multicsv), i, nb)
             @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
-            CloudStore.write(mus_obj, buf;)
+            #CloudStore.write(mus_obj, buf;)
             i += N
         end
 
-        @enter CloudStore.close(mus_obj; credentials)
+        #CloudStore.close(mus_obj; credentials)
         obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)
     end
-end
+end=#
 
 @testset "CloudStore.MultipartUploadStream write large bytes - Azure" begin
     Azurite.with(; debug=true) do conf
@@ -827,14 +827,14 @@ end
         mus_obj = CloudStore.MultipartUploadStream(bucket, "test.csv"; credentials)
 
         i = 1
-        while i < sizeof(multicsv)
+        #while i < sizeof(multicsv)
             nb = i + N > length(multicsv) ? length(multicsv)-i+1 : N
             buf = Vector{UInt8}(undef, nb)
             copyto!(buf, 1, codeunits(multicsv), i, nb)
             @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
             CloudStore.write(mus_obj, buf;)
             i += N
-        end
+        #end
 
         CloudStore.close(mus_obj; credentials)
         obj = CloudStore.Object(bucket, "test.csv"; credentials)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ check(x::IO, y::AbstractVector{UInt8}) = begin; reset!(x); z = read(x) == y; res
 check(x, y) = begin; reset!(x); reset!(y); z = read(x) == read(y); reset!(x); reset!(y); z end
 
 @testset "CloudStore.jl" begin
-#=@testset "S3" begin
+@testset "S3" begin
     # conf, p = Minio.run(; debug=true)
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
@@ -134,9 +134,9 @@ check(x, y) = begin; reset!(x); reset!(y); z = read(x) == read(y); reset!(x); re
             end
         end
     end
-end=#
+end
 
-#=@time @testset "Blobs" begin
+@time @testset "Blobs" begin
     # conf, p = Azurite.run(; debug=true)
     Azurite.with(; debug=true) do conf
         credentials, container = conf
@@ -791,7 +791,7 @@ end
         @test buf == view(codeunits(multicsv), 1:N)
         @test read(ioobj, UInt8) == UInt8(last(multicsv))
     end
-end=#
+end
 
 @testset "CloudStore.MultipartUploadStream write large bytes - S3" begin
     Minio.with(; debug=true) do conf

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -799,7 +799,6 @@ end
 @testset "CloudStore.MultipartUploadStream write large bytes - S3" begin
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
-        @show bucket
         multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
 
         N = 5500000
@@ -815,6 +814,7 @@ end
             i += N
         end
 
+        CloudStore.wait(mus_obj)
         CloudStore.close(mus_obj; credentials)
         obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)
@@ -839,6 +839,7 @@ end
             i += N
         end
 
+        CloudStore.wait(mus_obj)
         CloudStore.close(mus_obj; credentials)
         obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -793,6 +793,9 @@ end
     end
 end
 
+# When using Minio, the minimum upload size per part is 5MB according to
+# S3 specifications: https://github.com/minio/minio/issues/11076
+# I couldn't find a minimum upload size for Azure blob storage.
 @testset "CloudStore.MultipartUploadStream write large bytes - S3" begin
     Minio.with(; debug=true) do conf
         credentials, bucket = conf

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -799,6 +799,7 @@ end
 @testset "CloudStore.MultipartUploadStream write large bytes - S3" begin
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
+        @show bucket
         multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
 
         N = 5500000

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -818,7 +818,7 @@ end=#
     end
 end
 
-@testset "CloudStore.MultipartUploadStream write large bytes - Azure" begin
+#=@testset "CloudStore.MultipartUploadStream write large bytes - Azure" begin
     Azurite.with(; debug=true) do conf
         credentials, bucket = conf
         multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
@@ -840,6 +840,6 @@ end
         obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)
     end
-end
+end=#
 
 end # @testset "CloudStore.jl"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -369,8 +369,8 @@ end
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
         multicsv = "1,2,3,4,5,6,7,8,9,1\n"^10; # 200 B
-        S3.put(bucket, "test_nantia.csv", codeunits(multicsv); credentials)
-        obj = CloudStore.Object(bucket, "test_nantia.csv"; credentials)
+        S3.put(bucket, "test.csv", codeunits(multicsv); credentials)
+        obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)
 
         N = 19
@@ -378,7 +378,7 @@ end
         copyto!(buf, 1, obj, 1, N)
         @test buf == view(codeunits(multicsv), 1:N)
 
-        ioobj = CloudStore.PrefetchedDownloadStream(bucket, "test_nantia.csv", 16; credentials)
+        ioobj = CloudStore.PrefetchedDownloadStream(bucket, "test.csv", 16; credentials)
         i = 1
         while i < sizeof(multicsv)
             nb = i + N > length(multicsv) ? length(multicsv) - i : N

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -809,7 +809,6 @@ end
             nb = i + N > length(multicsv) ? length(multicsv)-i+1 : N
             buf = Vector{UInt8}(undef, nb)
             copyto!(buf, 1, codeunits(multicsv), i, nb)
-            @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
             CloudStore.write(mus_obj, buf;)
             i += N
         end
@@ -818,6 +817,49 @@ end
         CloudStore.close(mus_obj; credentials)
         obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)
+    end
+end
+
+@testset "CloudStore.MultipartUploadStream failure due to too small upload size - S3" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
+
+        N = 55000
+        mus_obj = CloudStore.MultipartUploadStream(bucket, "test.csv"; credentials)
+        try
+            i = 1
+            nb = i + N > length(multicsv) ? length(multicsv)-i+1 : N
+            buf = Vector{UInt8}(undef, nb)
+            copyto!(buf, 1, codeunits(multicsv), i, nb)
+            CloudStore.write(mus_obj, buf;)
+            CloudStore.wait(mus_obj)
+            CloudStore.close(mus_obj; credentials) # This should fail
+        catch e
+            @test isnothing(mus_obj.exc) == false
+        end
+    end
+end
+
+@testset "CloudStore.MultipartUploadStream failure due to changed url - S3" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
+
+        N = 5500000
+        mus_obj = CloudStore.MultipartUploadStream(bucket, "test.csv"; credentials)
+        try
+            i = 1
+            nb = i + N > length(multicsv) ? length(multicsv)-i+1 : N
+            buf = Vector{UInt8}(undef, nb)
+            copyto!(buf, 1, codeunits(multicsv), i, nb)
+            # Changing the url after the MultipartUploadStream object was created
+            mus_obj.url = "http://127.0.0.1:23252/jl-minio-22377/test_nantia.csv"
+            CloudStore.write(mus_obj, buf;) # This should fail
+            CloudStore.wait(mus_obj)
+        catch e
+            @test isnothing(mus_obj.exc) == false
+        end
     end
 end
 
@@ -834,7 +876,6 @@ end
             nb = i + N > length(multicsv) ? length(multicsv)-i+1 : N
             buf = Vector{UInt8}(undef, nb)
             copyto!(buf, 1, codeunits(multicsv), i, nb)
-            @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
             CloudStore.write(mus_obj, buf;)
             i += N
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ check(x::IO, y::AbstractVector{UInt8}) = begin; reset!(x); z = read(x) == y; res
 check(x, y) = begin; reset!(x); reset!(y); z = read(x) == read(y); reset!(x); reset!(y); z end
 
 @testset "CloudStore.jl" begin
-#=@testset "S3" begin
+@testset "S3" begin
     # conf, p = Minio.run(; debug=true)
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
@@ -363,7 +363,7 @@ end
         ok, accelerate, host, bucket, reg, key = CloudStore.parseAWSBucketRegionKey(url; parseLocal=true)
         @test !ok
     end
-end =#
+end
 
 @testset "CloudStore.PrefetchedDownloadStream small readbytes!" begin
     Minio.with(; debug=true) do conf
@@ -389,7 +389,7 @@ end =#
     end
 end
 
-#=@testset "CloudStore.PrefetchedDownloadStream large readbytes!" begin
+@testset "CloudStore.PrefetchedDownloadStream large readbytes!" begin
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
         multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20 MB
@@ -791,70 +791,30 @@ end
         @test buf == view(codeunits(multicsv), 1:N)
         @test read(ioobj, UInt8) == UInt8(last(multicsv))
     end
-end=#
-
-@testset "CloudStore.MultipartUploadStream" begin
-    Minio.with(; debug=true) do conf
-        credentials, bucket = conf
-        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^10; # 200 B
-        #S3.put(bucket, "test.csv", codeunits(multicsv); credentials)
-        #@show S3.get(bucket, "test.csv"; credentials)
-        #obj = CloudStore.Object(bucket, "test.csv"; credentials)
-        #@test length(obj) == sizeof(multicsv)
-        @show sizeof(multicsv)
-        @show credentials
-
-        N = 200
-        buf = Vector{UInt8}(undef, N)
-        #copyto!(buf, 1, codeunits(multicsv), 1, N)
-        #@test buf == view(codeunits(multicsv), 1:N)
-
-        mus_obj = CloudStore.MultipartUploadStream(bucket, "test.csv"; credentials)
-
-        #CloudStore.write(mus_obj, buf;)
-        #CloudStore.write(mus_obj, buf;)
-
-        i = 1
-        while i < sizeof(multicsv)
-            nb = i + N > length(multicsv) ? length(multicsv) - i : N
-            @show nb
-            copyto!(buf, i, codeunits(multicsv), i, nb)
-            @show codeunits(multicsv)
-            CloudStore.write(mus_obj, buf;)
-            #@show length(mus_obj)
-            #readbytes!(ioobj, buf, N)
-            #@test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
-            i += N
-        end
-        CloudStore.close(mus_obj; credentials)
-        obj = CloudStore.Object(bucket, "test.csv"; credentials)
-        @show obj
-    end
 end
 
-
-#=@testset "CloudStore.PrefetchedDownloadStream small readbytes!" begin
+@testset "CloudStore.MultipartUploadStream write large bytes" begin
     Minio.with(; debug=true) do conf
         credentials, bucket = conf
-        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^10; # 200 B
-        S3.put(bucket, "test.csv", codeunits(multicsv); credentials)
-        obj = CloudStore.Object(bucket, "test.csv"; credentials)
-        @test length(obj) == sizeof(multicsv)
+        multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
 
-        N = 19
-        buf = Vector{UInt8}(undef, N)
-        copyto!(buf, 1, obj, 1, N)
-        @test buf == view(codeunits(multicsv), 1:N)
+        N = 5500000
+        mus_obj = CloudStore.MultipartUploadStream(bucket, "test.csv"; credentials)
 
-        ioobj = CloudStore.PrefetchedDownloadStream(bucket, "test.csv", 16; credentials)
         i = 1
         while i < sizeof(multicsv)
-            nb = i + N > length(multicsv) ? length(multicsv) - i : N
-            readbytes!(ioobj, buf, N)
+            nb = i + N > length(multicsv) ? length(multicsv)-i+1 : N
+            buf = Vector{UInt8}(undef, nb)
+            copyto!(buf, 1, codeunits(multicsv), i, nb)
             @test view(buf, 1:nb) == view(codeunits(multicsv), i:i+nb-1)
+            CloudStore.write(mus_obj, buf;)
             i += N
         end
+
+        CloudStore.close(mus_obj; credentials)
+        obj = CloudStore.Object(bucket, "test.csv"; credentials)
+        @test length(obj) == sizeof(multicsv)
     end
-end=#
+end
 
 end # @testset "CloudStore.jl"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -818,7 +818,7 @@ end=#
     end
 end
 
-#=@testset "CloudStore.MultipartUploadStream write large bytes - Azure" begin
+@testset "CloudStore.MultipartUploadStream write large bytes - Azure" begin
     Azurite.with(; debug=true) do conf
         credentials, bucket = conf
         multicsv = "1,2,3,4,5,6,7,8,9,1\n"^1000000; # 20MB
@@ -840,6 +840,6 @@ end
         obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)
     end
-end=#
+end
 
 end # @testset "CloudStore.jl"


### PR DESCRIPTION
This PR adds a `MultipartUploadStream` IO object in `CloudStore.jl`, which facilitates uploading a stream of data chunks to blob storage. After creating a `MultipartUploadStream` object, we can repeatedly call `write()` and upload each part till there are no more chunks, when we can complete uploading and close the stream.