### PR TITLE
Don't assume the only error in getObject is an ArgumentError

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CloudBase = "85eb1798-d7c4-4918-bb13-c944d38e27ed"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 CodecZlibNG = "642d12eb-acb5-4437-bcfc-a25e07ad685c"
+ExceptionUnwrapping = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
@@ -19,16 +20,19 @@ Base64 = "1"
 CloudBase = "1"
 CodecZlib = "0.7"
 CodecZlibNG = "0.1"
+ExceptionUnwrapping = "0.1"
 HTTP = "1.7"
 Mmap = "1"
 TranscodingStreams = "0.9.12"
+Sockets = "1"
 WorkerUtilities = "1.1"
 XMLDict = "0.4"
 julia = "1.6"
 
 [extras]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CodecZlib", "Test"]
+test = ["CodecZlib", "Sockets", "Test"]

--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -12,6 +12,7 @@ export Object, PrefetchedDownloadStream, ResponseBodyType, RequestBodyType,
 using HTTP, CodecZlib, CodecZlibNG, Mmap
 import WorkerUtilities: OrderedSynchronizer
 import CloudBase: AbstractStore
+using ExceptionUnwrapping
 
 """
 Controls the automatic use of concurrency when downloading/uploading.

--- a/src/get.jl
+++ b/src/get.jl
@@ -73,6 +73,29 @@ function Base.getindex(b::BufferBatch, i::Int)
     end
 end
 
+# For smaller object, we don't do a multipart download, but instead just do a single GET request.
+# This changes the exception we get when the provided buffer is too small, as for the multipart
+# case, we do a HEAD request first to know the size of the object, which gives us the opportunity
+# to throw an ArgumentError. But for the single GET case, we don't know the size of the object
+# until we get the response, which would return as a HTTP.RequestError from within HTTP.jl.
+# The idea here is to unwrap the HTTP.RequestError and check if it's an ArgumentError, and if so,
+# throw that instead, so we same exception type is thrown in this case.
+# TODO(PR): Do we want to do this? If yes, do we want to make the messages the same?
+function _check_buffer_too_small_exception(@nospecialize(e::Exception))
+    if e isa HTTP.RequestError
+        request_error = e.error
+        if request_error isa CompositeException
+            length(request_error.exceptions) == 1 || return e
+            request_error = request_error.exceptions[1]
+        end
+        request_error = unwrap_exception(request_error)
+        if request_error isa ArgumentError
+            return request_error
+        end
+    end
+    return e
+end
+
 function getObjectImpl(x::AbstractStore, key::String, out::ResponseBodyType=nothing;
     multipartThreshold::Int=MULTIPART_THRESHOLD,
     partSize::Int=MULTIPART_SIZE,
@@ -124,8 +147,9 @@ function getObjectImpl(x::AbstractStore, key::String, out::ResponseBodyType=noth
         elseif out isa AbstractVector{UInt8}
             resp = try
                 getObject(x, url, headers; response_stream=out, kw...)
-            catch
-                throw(ArgumentError("provided output buffer (length = $(length(out))) is too small for actual cloud object size"))
+            catch e
+                e = _check_buffer_too_small_exception(e)
+                rethrow(e)
             end
         elseif out isa String
             if decompress

--- a/src/get.jl
+++ b/src/get.jl
@@ -80,7 +80,6 @@ end
 # until we get the response, which would return as a HTTP.RequestError from within HTTP.jl.
 # The idea here is to unwrap the HTTP.RequestError and check if it's an ArgumentError, and if so,
 # throw that instead, so we same exception type is thrown in this case.
-# TODO(PR): Do we want to do this? If yes, do we want to make the messages the same?
 function _check_buffer_too_small_exception(@nospecialize(e::Exception))
     if e isa HTTP.RequestError
         request_error = e.error
@@ -196,7 +195,8 @@ function getObjectImpl(x::AbstractStore, key::String, out::ResponseBodyType=noth
         res = body = Vector{UInt8}(undef, contentLength)
     elseif out isa AbstractVector{UInt8}
         # user-provided buffer is allowed to be larger than actual object size, but not smaller
-        length(out) < contentLength && throw(ArgumentError("out ($(length(out))) must at least be of length $contentLength"))
+        # NOTE: wording of the error message matches what HTTP.jl throws when the buffer is too small
+        length(out) < contentLength && throw(ArgumentError("Unable to grow response stream IOBuffer $(length(out)) large enough for response body size: $(contentLength)"))
         res = out
         body = view(out, 1:contentLength)
     elseif out isa String

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,7 +162,7 @@ check(x, y) = begin; reset!(x); reset!(y); z = read(x) == read(y); reset!(x); re
                     @test false # Should have thrown an error
                 catch e
                     @test e isa ArgumentError
-                    @test e.msg == "out ($(sizeof(out))) must at least be of length $(sizeof(csv))"
+                    @test e.msg == "Unable to grow response stream IOBuffer $(sizeof(out)) large enough for response body size: $(sizeof(csv))"
                 end
             end
 
@@ -376,7 +376,7 @@ end
                     @test false # Should have thrown an error
                 catch e
                     @test e isa ArgumentError
-                    @test e.msg == "out ($(sizeof(out))) must at least be of length $(sizeof(csv))"
+                    @test e.msg == "Unable to grow response stream IOBuffer $(sizeof(out)) large enough for response body size: $(sizeof(csv))"
                 end
             end
 


### PR DESCRIPTION
There are two main codepaths for `get` -- we either do a multipart download for larger files or a single `GET` call for smaller ones. When we give the method a preallocated buffer, we also constrain the maximum size of the object we want to download (anything bigger than the buffer should fail). When the object is larger than the buffer, the error handling is different for the two codepaths:

1. multipart download starts with a single `HEAD` call to learn the size of the object, and once we know it, we can compare it with the provided buffer, and throw an `ArgumentError` early. 

2. For small files, we don't do the extra `HEAD` request, but we let `HTTP.jl` handle the case internally in the single `GET` call and if the buffer turned out to be too small, we'd get a `RequestError` _wrapping_ and `ArgumentError` back from `HTTP.jl`.

This means that depending on the size of the input buffer, we'd sometimes get an `ArgumentError` and sometimes a `RequestError` both communicating the same underlying problem -- the input buffer is too small.

My current understanding is that to make these exception types more predictable, we always threw an additional `ArgumentError` in the small file case, assuming that buffer size mismatch was the only possible source of error at the call site, but we've seen that other kinds of errors are possible and that the `ArgumentError` was hiding the actual problem in those cases.

I also _think_ that we used to do a `HEAD` request even for small files in the past and when we stopped doing that for performance reasons, we forgot that the `HEAD` was shielding the `GET` from various errors like 403, 404 and so on.

In this PR, we no longer throw an additional `ArgumentError` in the small file case, instead we inspect the `RequestError` and if it contains a single `ArgumentError` we rethrow that. This is done because it's backward compatible -- we wanted to throw an `ArgumentError` on buffer size mismatch before so we'll continue to do so. I'm not sure if this is the right call though, and would appreciate some feedback/discussion on that.