### PR TITLE
Experiment: Allow bucket names ending with `-s3alias` / starting with `xn--`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudStore"
 uuid = "3365d9ee-d53b-4a56-812d-5344d5b716d7"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.6.3"
+version = "1.6.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -40,7 +40,7 @@ function validate_bucket_name(bucket_name, accelerate)
     !(3 <= ncodeunits(bucket_name) <= 63)    && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names must be between 3 (min) and 63 (max) characters long."))
     occursin("..", bucket_name)              && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names must not contain two adjacent periods."))
     startswith(bucket_name, "xn--")          && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names must not start with the prefix `xn--`."))
-    endswith(bucket_name, "-s3alias")        && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names must not end with the suffix `-s3alias`."))
+    # endswith(bucket_name, "-s3alias")        && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names must not end with the suffix `-s3alias`."))
     accelerate && occursin(".", bucket_name) && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Buckets used with Amazon S3 Transfer Acceleration can't have dots (.) in their names."))
     !contains(bucket_name, r"^[a-z0-9][\.\-a-z0-9]+[a-z0-9]$") &&
         throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-). Bucket names must begin and end with a letter or number."))

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -39,8 +39,6 @@ const AWS_REGIONS = Set{String}([
 function validate_bucket_name(bucket_name, accelerate)
     !(3 <= ncodeunits(bucket_name) <= 63)    && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names must be between 3 (min) and 63 (max) characters long."))
     occursin("..", bucket_name)              && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names must not contain two adjacent periods."))
-    startswith(bucket_name, "xn--")          && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names must not start with the prefix `xn--`."))
-    # endswith(bucket_name, "-s3alias")        && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names must not end with the suffix `-s3alias`."))
     accelerate && occursin(".", bucket_name) && throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Buckets used with Amazon S3 Transfer Acceleration can't have dots (.) in their names."))
     !contains(bucket_name, r"^[a-z0-9][\.\-a-z0-9]+[a-z0-9]$") &&
         throw(ArgumentError("Validation failed for `bucket` name $(repr(bucket_name)): Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-). Bucket names must begin and end with a letter or number."))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -884,8 +884,8 @@ end
         @test !parse_s3_url(bucket="a..b", accelerate=false)[1]
         @test_throws ArgumentError CloudStore.validate_bucket_name("xn--abc", false)
         @test_throws ArgumentError parse_s3_url(bucket="xn--abc", accelerate=false)
-        @test_throws ArgumentError CloudStore.validate_bucket_name("abcs-s3alias", false)
-        @test_throws ArgumentError parse_s3_url(bucket="abcs-s3alias", accelerate=false)
+        # @test_throws ArgumentError CloudStore.validate_bucket_name("abcs-s3alias", false)
+        # @test_throws ArgumentError parse_s3_url(bucket="abcs-s3alias", accelerate=false)
         @test_throws ArgumentError CloudStore.validate_bucket_name("abcA", false)
         @test_throws ArgumentError parse_s3_url(bucket="abcA", accelerate=false)
         @test_throws ArgumentError CloudStore.validate_bucket_name("abc-", false)
@@ -911,8 +911,8 @@ end
         @test !parse_s3_url(bucket="a..b", accelerate=true)[1]
         @test_throws ArgumentError CloudStore.validate_bucket_name("xn--abc", true)
         @test_throws ArgumentError parse_s3_url(bucket="xn--abc", accelerate=true)
-        @test_throws ArgumentError CloudStore.validate_bucket_name("abcs-s3alias", true)
-        @test_throws ArgumentError parse_s3_url(bucket="abcs-s3alias", accelerate=true)
+        # @test_throws ArgumentError CloudStore.validate_bucket_name("abcs-s3alias", true)
+        # @test_throws ArgumentError parse_s3_url(bucket="abcs-s3alias", accelerate=true)
         @test_throws ArgumentError CloudStore.validate_bucket_name("abcA", true)
         @test_throws ArgumentError parse_s3_url(bucket="abcA", accelerate=true)
         @test_throws ArgumentError CloudStore.validate_bucket_name("abc-", true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -882,10 +882,6 @@ end
         @test_throws ArgumentError parse_s3_url(bucket="a"^64, accelerate=false)
         @test_throws ArgumentError CloudStore.validate_bucket_name("a..b", false)
         @test !parse_s3_url(bucket="a..b", accelerate=false)[1]
-        @test_throws ArgumentError CloudStore.validate_bucket_name("xn--abc", false)
-        @test_throws ArgumentError parse_s3_url(bucket="xn--abc", accelerate=false)
-        # @test_throws ArgumentError CloudStore.validate_bucket_name("abcs-s3alias", false)
-        # @test_throws ArgumentError parse_s3_url(bucket="abcs-s3alias", accelerate=false)
         @test_throws ArgumentError CloudStore.validate_bucket_name("abcA", false)
         @test_throws ArgumentError parse_s3_url(bucket="abcA", accelerate=false)
         @test_throws ArgumentError CloudStore.validate_bucket_name("abc-", false)
@@ -909,10 +905,6 @@ end
         @test_throws ArgumentError parse_s3_url(bucket="a"^64, accelerate=true)
         @test_throws ArgumentError CloudStore.validate_bucket_name("a..b", true)
         @test !parse_s3_url(bucket="a..b", accelerate=true)[1]
-        @test_throws ArgumentError CloudStore.validate_bucket_name("xn--abc", true)
-        @test_throws ArgumentError parse_s3_url(bucket="xn--abc", accelerate=true)
-        # @test_throws ArgumentError CloudStore.validate_bucket_name("abcs-s3alias", true)
-        # @test_throws ArgumentError parse_s3_url(bucket="abcs-s3alias", accelerate=true)
         @test_throws ArgumentError CloudStore.validate_bucket_name("abcA", true)
         @test_throws ArgumentError parse_s3_url(bucket="abcA", accelerate=true)
         @test_throws ArgumentError CloudStore.validate_bucket_name("abc-", true)
@@ -927,6 +919,11 @@ end
         @test CloudStore.validate_bucket_name("a.b-c1", false) == "a.b-c1"
         @test CloudStore.validate_bucket_name("a"^63, false) == "a"^63
         @test CloudStore.validate_bucket_name("a"^3, false) == "a"^3
+        # xn-- prefix and -s3alias suffix are apparently illegal in bucket names create by
+        # the user but can be received from AWS, see e.g.
+        # https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-alias.html
+        @test CloudStore.validate_bucket_name("xn--a", false) == "xn--a"
+        @test CloudStore.validate_bucket_name("a-s3alias", false) == "a-s3alias"
 
         @test_throws ArgumentError("Validation failed for `region` \"xx-xxxx-x\"") CloudStore.parseAWSBucketRegionKey("https://bucket.vpce-1a2b3c4d-5e6f.s3.xx-xxxx-x.vpce.amazonaws.com/bucket-name")
         @test_throws ArgumentError("Validation failed for `bucket` name \"bn\": Bucket names must be between 3 (min) and 63 (max) characters long.") CloudStore.parseAWSBucketRegionKey("https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com/bn")


### PR DESCRIPTION
Apparently, these are illegal in the name of buckets created by the user but are valid for AWS to create.