### PR TITLE
Encode object keys in request URLs

### DIFF
--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -30,7 +30,12 @@ asArray(x::Array) = x
 asArray(x) = [x]
 
 etag(x) = strip(x, '"')
-makeURL(x::AbstractStore, key) = joinpath(x.baseurl, lstrip(key, '/'))
+
+function makeURL(x::AbstractStore, key)
+    parts = split(lstrip(key, '/'), '/'; keepempty=true)
+    escaped = join(HTTP.escapeuri.(parts), '/')
+    return joinpath(x.baseurl, escaped)
+end
 
 include("object.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,6 +62,18 @@ RecordingStore(; fail_part=nothing) = RecordingStore(
     fail_part,
 )
 
+@testset "object key URL encoding" begin
+    store = RecordingStore()
+    @test CloudStore.API.makeURL(store, "plain") == "https://recording.example/plain"
+    @test CloudStore.API.makeURL(store, "nested/key") == "https://recording.example/nested/key"
+    @test CloudStore.API.makeURL(store, "nested//key") == "https://recording.example/nested//key"
+    @test CloudStore.API.makeURL(store, "with space") == "https://recording.example/with%20space"
+    @test CloudStore.API.makeURL(store, "with%20space") == "https://recording.example/with%2520space"
+    @test CloudStore.API.makeURL(store, "plus+plus") == "https://recording.example/plus%2Bplus"
+    @test CloudStore.API.makeURL(store, "hash#hash") == "https://recording.example/hash%23hash"
+    @test CloudStore.API.makeURL(store, "unicode-ü") == "https://recording.example/unicode-%C3%BC"
+end
+
 CloudStore.API.startMultipartUpload(::RecordingStore, _key; kw...) = nothing
 
 function CloudStore.API.uploadPart(store::RecordingStore, _url, part, part_number, _state; kw...)


### PR DESCRIPTION
## Summary

- percent-encode each object-key path segment before URL construction
- preserve nested and repeated-slash key structure
- keep literal percent sequences distinct from already escaped URL text
- add direct coverage for spaces, `%`, `+`, `#`, Unicode, and nested keys

This is the URL-construction half of JuliaServices/CloudBase.jl#44. It pairs with JuliaServices/CloudBase.jl#45, which corrects AWS SigV4 canonical-path signing.

## Validation

- full CloudStore test suite passes: 1,269 tests
- combined CloudStore + CloudBase MinIO round trips pass for plain, nested, space, literal `%20`, `+`, `#`, and Unicode keys

Refs JuliaServices/CloudBase.jl#44

Co-authored by Codex