### PR TITLE
Deploy docs with the repository token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/julia-buildpkg@latest
@@ -46,4 +48,3 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,26 @@ jobs:
           file: lcov.info
   docs:
     name: Documentation
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Build documentation
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'
+        env:
+          DOCUMENTER_BUILD_ONLY: "true"
+  docs-deploy:
+    name: Documentation
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/julia-buildpkg@latest
-      - name: Build documentation
-        if: github.event_name == 'pull_request'
-        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'
-        env:
-          DOCUMENTER_BUILD_ONLY: "true"
       - uses: julia-actions/julia-docdeploy@latest
-        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- keep pull-request documentation builds in a read-only job
- deploy documentation from a separate trusted job with repository-content write access
- use `GITHUB_TOKEN` for Documenter deployment
- remove the stale SSH deploy-key dependency

## Root cause

The package and documentation build passed on `main`, but Documenter selected `DOCUMENTER_KEY` and failed to authenticate over SSH. Pull requests did not expose this because they only build documentation and do not deploy it.

## Validation

- reproduced from failed `main` run 30627919386
- confirmed the failure is limited to `git fetch upstream` with `Permission denied (publickey)`
- workflow parses as valid YAML
- `git diff --check` passes
- pull-request jobs retain read-only repository access

Co-authored by Codex