### PR TITLE
Replace placeholder docs with a CloudStore guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 # CloudStore
 
 [![CI](https://github.com/JuliaServices/CloudStore.jl/workflows/CI/badge.svg)](https://github.com/JuliaServices/CloudStore.jl/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/JuliaServices/CloudStore.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaServices/CloudStore.jl)
+[![codecov](https://codecov.io/gh/JuliaServices/CloudStore.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaServices/CloudStore.jl)
 [![deps](https://juliahub.com/docs/CloudStore/deps.svg)](https://juliahub.com/ui/Packages/CloudStore/HHBkp?t=2)
 [![version](https://juliahub.com/docs/CloudStore/version.svg)](https://juliahub.com/ui/Packages/CloudStore/HHBkp)
 [![pkgeval](https://juliahub.com/docs/CloudStore/pkgeval.svg)](https://juliahub.com/ui/Packages/CloudStore/HHBkp)
 
-*A simple, consistent, and performant API for interacting with common cloud storage abstractions in Julia (GCP, Azure Blob Storage, AWS S3)*
+*A simple, consistent, and performant API for Amazon S3 and Azure Blob Storage in Julia.*
 
 ## Installation
 
@@ -34,9 +34,9 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 [docs-stable-url]: https://juliaservices.github.io/CloudStore.jl/stable
 
 [ci-img]: https://github.com/JuliaServices/CloudStore.jl/workflows/CI/badge.svg
-[ci-url]: https://github.com/JuliaServices/CloudStore.jl/actions?query=workflow%3ACI+branch%3Amaster
+[ci-url]: https://github.com/JuliaServices/CloudStore.jl/actions?query=workflow%3ACI+branch%3Amain
 
-[codecov-img]: https://codecov.io/gh/JuliaServices/CloudStore.jl/branch/master/graph/badge.svg
+[codecov-img]: https://codecov.io/gh/JuliaServices/CloudStore.jl/branch/main/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaServices/CloudStore.jl
 
 [issues-url]: https://github.com/JuliaServices/CloudStore.jl/issues

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 CloudStore = "3365d9ee-d53b-4a56-812d-5344d5b716d7"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,17 +1,28 @@
 using Documenter, CloudStore
 
 makedocs(;
+    modules=[CloudStore],
+    authors="CloudStore.jl contributors",
     pages=[
         "Home" => "index.md",
+        "Object operations" => "objects.md",
+        "Streaming transfers" => "streaming.md",
         "API Reference" => "reference.md",
     ],
     sitename="CloudStore.jl",
+    format=Documenter.HTML(;
+        canonical="https://juliaservices.github.io/CloudStore.jl/stable",
+        prettyurls=get(ENV, "CI", "false") == "true",
+        repolink="https://github.com/JuliaServices/CloudStore.jl",
+    ),
+    checkdocs=:exports,
+    warnonly=false,
 )
 
 if get(ENV, "DOCUMENTER_BUILD_ONLY", "false") != "true"
     deploydocs(;
         repo="github.com/JuliaServices/CloudStore.jl",
-        devbranch = "main",
-        push_preview = true,
+        devbranch="main",
+        push_preview=true,
     )
 end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,54 +1,84 @@
-# CloudStore.jl Documentation
+# CloudStore.jl
 
-GitHub Repo: [https://github.com/JuliaServices/CloudStore.jl](https://github.com/JuliaServices/CloudStore.jl)
+CloudStore.jl provides one object-storage interface for Amazon S3 and Azure Blob Storage.
+It supports object listing, upload, download, metadata, deletion, parallel transfers, and
+streaming transfers.
 
-Welcome to CloudStore.jl! A simple, yet comprehensive foundation for interacting with common cloud providers in Julia (GCP, Azure, AWS).
+CloudStore uses [CloudBase.jl](https://github.com/JuliaServices/CloudBase.jl) for credentials
+and signed HTTP requests. It does not create buckets, containers, or other cloud resources.
 
 ## Installation
 
-You can install CloudStore by typing the following in the Julia REPL:
+Install CloudStore from the General registry:
+
 ```julia
-] add CloudStore 
+using Pkg
+Pkg.add("CloudStore")
 ```
 
-followed by 
+Load the package and the provider namespace that you need:
+
 ```julia
 using CloudStore
+
+const S3 = CloudStore.S3
+const Blobs = CloudStore.Blobs
 ```
-to load the package.
 
-## Overview 
+CloudStore keeps its public names inside the package namespace. It does not add common names
+such as `get`, `put`, or `delete` to your session.
 
-The CloudStore.jl package provides a set of foundational functionality for interacting with the most common
-cloud providers (GCP, Azure, and AWS). It specifically aims to *do* the following:
-  * Handle common credential scenarios, including the following in order of precedence:
-    * Allow manually provided credentials by user
-    * Loading credentials from cloud-idiomatic environment variables
-    * Loading credentials from cloud-idiomatic config/credential files
-    * Inspecting current host environment for additional credential options (EC2, ECS task, etc.)
-  * Handles automatic refresh attempts of credentials when they are close to expiring
-  * Provides custom HTTP.jl clients that includes layers to set appropriate default keyword arguments
-    for specific cloud configurations and handles request "signing" according to cloud-specific algorithms
+## Create a store
 
-The package specifically *does not* aim to do any of the following:
-  * Cloud-specific error handling/parsing for specific codes/problems
-  * URL/header/query parameter/request body validation of arguments for specific cloud service operations
-
-The core of the package then, is in 3 *non*-exported modules (that you can import yourself if so desired):
-  * `CloudStore.AWS`: provides `AWS.get`, `AWS.put`, `AWS.post`, `AWS.request` etc. as wrappers to corresponding `HTTP` methods
-  * `CloudStore.Azure`: provides `Azure.get`, `Azure.put`, `Azure.post`, `Azure.request` etc. as wrappers to corresponding `HTTP` methods
-  * `CloudStore.GCP`: provides `GCP.get`, `GCP.put`, `GCP.post`, `GCP.request` etc. as wrappers to corresponding `HTTP` methods
-
-That means *using* this packages behavior is basically like dropping in a cloud-specific module call in place
-of where you would have been calling HTTP.jl, like:
+Create an S3 bucket handle with its name and region:
 
 ```julia
-import CloudStore: AWS
-
-function get_file(url, creds)
-    # previously tried to do manual header auth signing manually or something and then call HTTP.get
-    # now can just call AWS.get w/ creds and it will do the request signing automatically
-    # right before the request is sent on the wire
-    return AWS.get(url; service="S3", region="us-west-1", access_key_id=creds.id, secret_access_key=creds.secret)
-end
+bucket = S3.Bucket("my-bucket", "us-west-2")
 ```
+
+Create an Azure container handle with its container name and storage account:
+
+```julia
+container = Blobs.Container("my-container", "mystorageaccount")
+```
+
+These constructors do not send a network request. They only create a handle for later
+operations.
+
+## Credentials
+
+CloudStore accepts `credentials` as a keyword argument. CloudBase can also load credentials
+from the standard environment, configuration files, and cloud-host metadata services.
+
+```julia
+data = CloudStore.get(bucket, "reports/today.csv"; credentials)
+```
+
+Do not put long-lived secrets in source code. Use your cloud provider's standard credential
+chain when possible.
+
+## Choose an interface
+
+The generic interface dispatches from the store type:
+
+```julia
+CloudStore.put(bucket, "hello.txt", codeunits("hello"))
+CloudStore.get(bucket, "hello.txt")
+```
+
+The provider namespaces offer the same operations:
+
+```julia
+S3.put(bucket, "hello.txt", codeunits("hello"))
+Blobs.put(container, "hello.txt", codeunits("hello"))
+```
+
+You can also use an S3 or Azure object URL. Provide `region` for an S3 URL when the URL does
+not contain it.
+
+```julia
+CloudStore.get("s3://my-bucket/reports/today.csv"; region="us-west-2")
+CloudStore.get("https://mystorageaccount.blob.core.windows.net/my-container/data.csv")
+```
+
+See [Object operations](@ref) for the complete transfer workflow.

--- a/docs/src/objects.md
+++ b/docs/src/objects.md
@@ -1,0 +1,117 @@
+# Object operations
+
+CloudStore accepts three forms for most object operations:
+
+- a store handle and object key;
+- a [`CloudStore.Object`](@ref);
+- an S3 or Azure object URL.
+
+The examples below use the generic `CloudStore` interface. The `CloudStore.S3` and
+`CloudStore.Blobs` namespaces provide matching methods.
+
+## Upload
+
+Upload bytes, text, an open `IO`, or a file path:
+
+```julia
+obj = CloudStore.put(bucket, "reports/today.csv", codeunits("a,b\n1,2\n"))
+obj = CloudStore.put(bucket, "reports/today.csv", IOBuffer(data))
+obj = CloudStore.put(bucket, "reports/today.csv", "/tmp/today.csv")
+```
+
+The return value is an [`Object`](@ref). It contains the store, key, byte size, and ETag.
+
+CloudStore starts a multipart upload above `multipartThreshold`. Control the transfer with
+`partSize` and `batchSize`:
+
+```julia
+obj = CloudStore.put(
+    bucket,
+    "large.bin",
+    data;
+    multipartThreshold=8 * 1024^2,
+    partSize=8 * 1024^2,
+    batchSize=8,
+)
+```
+
+Set `allowMultipart=false` to force one request. Set `compress=true` to gzip the uploaded
+bytes. CloudStore does not add `.gz` to the key.
+
+## Download
+
+Download into a new byte vector:
+
+```julia
+data = CloudStore.get(bucket, "reports/today.csv")
+```
+
+Download into an existing destination:
+
+```julia
+buffer = Vector{UInt8}(undef, expected_size)
+CloudStore.get(bucket, "large.bin", buffer)
+
+CloudStore.get(bucket, "large.bin", "/tmp/large.bin")
+
+open("/tmp/large.bin", "w") do io
+    CloudStore.get(bucket, "large.bin", io)
+end
+```
+
+Multipart downloads first read object metadata. Use `objectMaxSize` when you know an upper
+bound and want to avoid that request for a small object. Set `decompress=true` to gunzip the
+downloaded bytes.
+
+## Metadata and listing
+
+Read response headers without downloading the object:
+
+```julia
+headers = CloudStore.head(bucket, "reports/today.csv")
+content_length = parse(Int, headers["Content-Length"])
+```
+
+List every object, or limit the result to a prefix:
+
+```julia
+objects = CloudStore.list(bucket)
+reports = CloudStore.list(bucket; prefix="reports/")
+```
+
+CloudStore follows provider pagination until it has the complete result. `maxKeys` controls
+the page size. It does not limit the total returned object count.
+
+## Use an Object
+
+An upload or listing returns [`CloudStore.Object`](@ref) values. You can use an object as the
+source for later operations:
+
+```julia
+data = CloudStore.get(obj)
+headers = CloudStore.head(obj)
+CloudStore.delete(obj)
+```
+
+Constructing an object by key sends a metadata request:
+
+```julia
+obj = CloudStore.Object(bucket, "reports/today.csv")
+```
+
+## Delete
+
+Delete one object:
+
+```julia
+CloudStore.delete(bucket, "reports/today.csv")
+```
+
+CloudStore does not create or delete S3 buckets or Azure containers. Use the provider control
+plane for store lifecycle operations.
+
+## Pass request options
+
+Extra keyword arguments pass to the signed CloudBase HTTP request. This supports options such
+as timeouts, retries, and explicit credentials. Treat provider-specific headers and query
+parameters with care because they can change request signing.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,7 +1,27 @@
-# API Reference
+# API reference
 
-## Basics
+CloudStore uses a small namespace-based API. The main operations are:
+
+```julia
+CloudStore.list(store; kwargs...)
+CloudStore.get(store, key[, destination]; kwargs...)
+CloudStore.head(store, key; kwargs...)
+CloudStore.put(store, key, source; kwargs...)
+CloudStore.delete(store, key; kwargs...)
+```
+
+The same operation names are available as `CloudStore.S3.list`, `CloudStore.S3.get`, and so
+on, and as `CloudStore.Blobs.list`, `CloudStore.Blobs.get`, and so on.
+
+## Object
 
 ```@docs
+CloudStore.Object
+```
 
+## Transfer streams
+
+```@docs
+CloudStore.PrefetchedDownloadStream
+CloudStore.MultipartUploadStream
 ```

--- a/docs/src/streaming.md
+++ b/docs/src/streaming.md
@@ -1,0 +1,63 @@
+# Streaming transfers
+
+Use a stream when the complete object should not be in memory at one time.
+
+## Prefetched downloads
+
+[`CloudStore.PrefetchedDownloadStream`](@ref) reads ranges in parallel into two buffers.
+Construct it from an [`Object`](@ref):
+
+```julia
+obj = CloudStore.Object(bucket, "large.csv")
+io = CloudStore.PrefetchedDownloadStream(obj)
+try
+    while !eof(io)
+        row = readline(io)
+        # Process the row.
+    end
+finally
+    close(io)
+end
+```
+
+Tune the memory and request sizes when needed:
+
+```julia
+io = CloudStore.PrefetchedDownloadStream(
+    obj,
+    16 * 1024^2;
+    prefetch_multipart_size=2 * 1024^2,
+)
+```
+
+The first positional size is the size of each in-memory prefetch buffer. The keyword value is
+the maximum size of each range request. The stream is read-only and is not thread-safe.
+
+## Multipart uploads
+
+[`CloudStore.MultipartUploadStream`](@ref) sends each written byte vector as one part. The
+do-block form waits for all parts and completes the upload:
+
+```julia
+CloudStore.MultipartUploadStream(bucket, "generated.bin") do io
+    for chunk in chunks
+        write(io, chunk)
+    end
+end
+```
+
+Each `chunk` must be a `Vector{UInt8}`. Except for the final part, Amazon S3 requires parts to
+meet its minimum part size. Use `CloudStore.put` for small objects.
+
+Use the manual form only when you need direct lifecycle control:
+
+```julia
+io = CloudStore.MultipartUploadStream(bucket, "generated.bin")
+write(io, first_chunk)
+write(io, second_chunk)
+wait(io)
+close(io)
+```
+
+Keep chunks in object order. `concurrent_writes_to_channel` limits the number of uploads in
+flight and applies backpressure to `write`.

--- a/src/object.jl
+++ b/src/object.jl
@@ -3,6 +3,15 @@ import CloudBase: AbstractStore, CloudCredentials, AWS, Azure
 const DEFAULT_PREFETCH_SIZE = 32 * 1024 * 1024
 const DEFAULT_PREFETCH_MULTIPART_SIZE = 8 * 1024 * 1024
 
+"""
+    CloudStore.Object(store, key; credentials=nothing, kwargs...)
+
+A remote object in an S3 bucket or Azure Blob container.
+
+Constructing an `Object` from a store and key sends a metadata request. Upload and list
+operations also return `Object` values. The fields include `store`, `credentials`, `key`,
+`size`, `eTag`, and provider-specific `properties`.
+"""
 struct Object{T <: AbstractStore}
     store::T
     credentials::Union{Nothing, AWS.Credentials, Azure.Credentials}
@@ -171,7 +180,7 @@ The number of spawned tasks is also governed by these two parameters, with appro
 `prefetch_size` / `prefetch_multipart_size` tasks spawned for performing the GET requests
 (defaults to 4 if those fields aren't specified) + 1 task is spawned to coordinate the
 prefetching process. Number of spawned tasks is upper-bounded by the size of the input and
-the number of threads available (see [`_ndownload_tasks`](@ref) helper function).
+the number of threads available (see the internal `_ndownload_tasks` helper function).
 
 **Reading from this stream is not thread-safe**.
 


### PR DESCRIPTION
## Summary

- replace the copied CloudBase text with a CloudStore-specific guide
- document S3 and Azure setup, object operations, and streaming transfers
- add an API reference for the documented object and stream types
- make Documenter warnings fail the build
- correct stale GCP and `master` branch references

Fixes JuliaServices/CloudStore.jl#8.

## Validation

- built the site with Documenter 1.17
- doctests, cross-references, document checks, and HTML rendering passed with no warnings

Co-authored by Codex
