### PR TITLE
Add object existence checks

### DIFF
--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -46,6 +46,7 @@ function continuationToken end
 function listObjects end
 function getObject end
 function headObject end
+function existsObject end
 include("get.jl")
 function putObject end
 function startMultipartUpload end
@@ -62,6 +63,7 @@ include("parse.jl")
 # generic dispatches
 get(x::Object, out::ResponseBodyType=nothing; kw...) = get(x.store, x.key, out; kw...)
 head(x::Object; kw...) = head(x.store, x.key; kw...)
+exists(x::Object; kw...) = exists(x.store, x.key; kw...)
 put(x::Object, in::RequestBodyType; kw...) = put(x.store, x.key, in; kw...)
 delete(x::Object; kw...) = delete(x.store, x.key; kw...)
 
@@ -69,12 +71,14 @@ delete(x::Object; kw...) = delete(x.store, x.key; kw...)
 list(x::AWS.Bucket; kw...) = S3.list(x; kw...)
 get(x::AWS.Bucket, key::String, out::ResponseBodyType=nothing; kw...) = S3.get(x, key, out; kw...)
 head(x::AWS.Bucket, key::String; kw...) = S3.head(x, key; kw...)
+exists(x::AWS.Bucket, key::String; kw...) = S3.exists(x, key; kw...)
 put(x::AWS.Bucket, key::String, in::RequestBodyType; kw...) = S3.put(x, key, in; kw...)
 delete(x::AWS.Bucket, key::String; kw...) = S3.delete(x, key; kw...)
 
 list(x::Azure.Container; kw...) = Blobs.list(x; kw...)
 get(x::Azure.Container, key::String, out::ResponseBodyType=nothing; kw...) = Blobs.get(x, key, out; kw...)
 head(x::Azure.Container, key::String; kw...) = Blobs.head(x, key; kw...)
+exists(x::Azure.Container, key::String; kw...) = Blobs.exists(x, key; kw...)
 put(x::Azure.Container, key::String, in::RequestBodyType; kw...) = Blobs.put(x, key, in; kw...)
 delete(x::Azure.Container, key::String; kw...) = Blobs.delete(x, key; kw...)
 
@@ -86,6 +90,20 @@ end
 function head(url::AbstractString; region=nothing, nowarn::Bool=false, kw...)
     store, key = parseURLForDispatch(url, region, nowarn)
     return head(store, key; kw...)
+end
+
+"""
+    CloudStore.exists(store, key; kwargs...) -> Bool
+    CloudStore.exists(object; kwargs...) -> Bool
+    CloudStore.exists(url; kwargs...) -> Bool
+
+Return `true` when the object exists. Return `false` only when the provider returns
+HTTP 404. Other HTTP errors are rethrown so that authentication and service failures
+are not reported as missing objects.
+"""
+function exists(url::AbstractString; region=nothing, nowarn::Bool=false, kw...)
+    store, key = parseURLForDispatch(url, region, nowarn)
+    return exists(store, key; kw...)
 end
 
 function put(url::AbstractString, in::RequestBodyType; region=nothing, nowarn::Bool=false, kw...)

--- a/src/blobs.jl
+++ b/src/blobs.jl
@@ -49,6 +49,8 @@ get(args...; kw...) = API.getObjectImpl(args...; kw...)
 API.headObject(x::Container, url, headers; kw...) = Azure.head(url; headers, kw...)
 head(x::Object; kw...) = head(x.store, x.key; credentials=x.credentials, kw...)
 head(x::Container, key::String; kw...) = API.headObjectImpl(x, key; kw...)
+exists(x::Object; kw...) = exists(x.store, x.key; credentials=x.credentials, kw...)
+exists(x::Container, key::String; kw...) = API.existsObjectImpl(x, key; kw...)
 
 put(args...; kw...) = API.putObjectImpl(args...; kw...)
 put(x::Object; kw...) = put(x.store, x.key; credentials=x.credentials, kw...)
@@ -72,7 +74,7 @@ end
 delete(x::Container, key::String; kw...) = Azure.delete(API.makeURL(x, key); kw...)
 delete(x::Object; kw...) = delete(x.store, x.key; credentials=x.credentials, kw...)
 
-for func in (:list, :get, :head, :put, :delete)
+for func in (:list, :get, :head, :exists, :put, :delete)
     @eval function $func(url::AbstractString, args...; parseLocal::Bool=false, kw...)
         ok, host, account, container, blob = parseAzureAccountContainerBlob(url; parseLocal=parseLocal)
         ok || throw(ArgumentError("invalid url for Blobs.$($func): `$url`"))

--- a/src/get.jl
+++ b/src/get.jl
@@ -33,6 +33,16 @@ function headObjectImpl(x::AbstractStore, key::String;
     return Dict(headObject(x, url, headers; kw...).headers)
 end
 
+function existsObjectImpl(x::AbstractStore, key::String;
+    headers=HTTP.Headers(), kw...)
+    url = makeURL(x, key)
+    request_kw = merge((; kw...), (; status_exception=false))
+    resp = headObject(x, url, headers; request_kw...)
+    resp.status == 404 && return false
+    200 <= resp.status < 300 && return true
+    throw(HTTP.StatusError(resp.status, resp.request.method, resp.request.target, resp))
+end
+
 # Content-Range: bytes 0-9/443
 contentRange(rng) = "Range" => "bytes=$(first(rng))-$(last(rng))"
 

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -35,6 +35,8 @@ get(args...; kw...) = API.getObjectImpl(args...; kw...)
 API.headObject(x::Bucket, url, headers; kw...) = AWS.head(url; headers, service="s3", kw...)
 head(x::Object; kw...) = head(x.store, x.key; credentials=x.credentials, kw...)
 head(x::Bucket, key::String; kw...) = API.headObjectImpl(x, key; kw...)
+exists(x::Object; kw...) = exists(x.store, x.key; credentials=x.credentials, kw...)
+exists(x::Bucket, key::String; kw...) = API.existsObjectImpl(x, key; kw...)
 
 put(args...; kw...) = API.putObjectImpl(args...; kw...)
 put(x::Object; kw...) = put(x.store, x.key; credentials=x.credentials, kw...)
@@ -60,7 +62,7 @@ end
 delete(x::Bucket, key; kw...) = AWS.delete(API.makeURL(x, key); service="s3", kw...)
 delete(x::Object; kw...) = delete(x.store, x.key; credentials=x.credentials, kw...)
 
-for func in (:list, :get, :head, :put, :delete)
+for func in (:list, :get, :head, :exists, :put, :delete)
     @eval function $func(url::AbstractString, args...; region=nothing, nowarn::Bool=false, parseLocal::Bool=false, kw...)
         ok, accelerate, host, bucket, reg, key = parseAWSBucketRegionKey(url; parseLocal=parseLocal)
         ok || throw(ArgumentError("invalid url for S3.$($func): `$url`"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using Test, CloudStore, CloudBase.CloudTest
 import CloudBase
 import CloudStore: S3, Blobs
 using CodecZlib
+import HTTP
+import Sockets
 using HTTP: ConnectError, StatusError
 using Sockets: DNSError
 using ExceptionUnwrapping: unwrap_exception
@@ -72,6 +74,34 @@ RecordingStore(; fail_part=nothing) = RecordingStore(
     @test CloudStore.API.makeURL(store, "plus+plus") == "https://recording.example/plus%2Bplus"
     @test CloudStore.API.makeURL(store, "hash#hash") == "https://recording.example/hash%23hash"
     @test CloudStore.API.makeURL(store, "unicode-ü") == "https://recording.example/unicode-%C3%BC"
+end
+
+@testset "object existence" begin
+    port, socket = Sockets.listenany(Sockets.IPv4(0), 20_000)
+    close(socket)
+    server = HTTP.serve!(port; verbose=false) do request
+        status = endswith(request.target, "/present") ? 200 :
+            endswith(request.target, "/missing") ? 404 : 403
+        return HTTP.Response(status)
+    end
+    try
+        bucket = S3.Bucket("bucket-name", "us-east-1"; host="http://127.0.0.1:$port")
+        @test S3.exists(bucket, "present")
+        @test !S3.exists(bucket, "missing")
+        @test_throws StatusError S3.exists(bucket, "forbidden")
+        @test CloudStore.exists(bucket, "present")
+
+        container = Blobs.Container("container", "account"; host="http://127.0.0.1:$port")
+        @test Blobs.exists(container, "present")
+        @test !Blobs.exists(container, "missing")
+        @test_throws StatusError Blobs.exists(container, "forbidden")
+        @test CloudStore.exists(container, "present")
+
+        object = CloudStore.Object(bucket, nothing, "present", 0, "")
+        @test CloudStore.exists(object)
+    finally
+        close(server)
+    end
 end
 
 CloudStore.API.startMultipartUpload(::RecordingStore, _key; kw...) = nothing


### PR DESCRIPTION
## Summary

- add `CloudStore.exists` for stores, objects, and object URLs
- add matching `S3.exists` and `Blobs.exists` methods
- return `false` only for HTTP 404
- preserve authentication and service failures as errors

Fixes JuliaServices/CloudStore.jl#36.

## Validation

- full CloudStore test suite passed
- local HTTP tests cover S3 and Azure success, missing objects, and forbidden responses
- local MinIO and Azurite integration tests passed

Co-authored by Codex
