### PR TITLE
Preserve query strings in signed object URLs

### DIFF
--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -26,6 +26,21 @@ defaultBatchSize() = 4 * Threads.nthreads()
 const ResponseBodyType = Union{Nothing, AbstractVector{UInt8}, String, IO}
 const RequestBodyType = Union{AbstractVector{UInt8}, String, IO}
 
+struct ParsedURLResource
+    path::String
+    query::String
+end
+
+const Resource = Union{AbstractString,ParsedURLResource}
+
+function parsedURLResource(resource::AbstractString)
+    parts = split(String(resource), '?'; limit=2, keepempty=true)
+    return length(parts) == 1 ? only(parts) : ParsedURLResource(parts...)
+end
+
+resourceKey(resource::AbstractString) = String(resource)
+resourceKey(resource::ParsedURLResource) = resource.path
+
 asArray(x::Array) = x
 asArray(x) = [x]
 
@@ -36,6 +51,9 @@ function makeURL(x::AbstractStore, key)
     escaped = join(HTTP.escapeuri.(parts), '/')
     return joinpath(x.baseurl, escaped)
 end
+
+makeURL(x::AbstractStore, resource::ParsedURLResource) =
+    string(makeURL(x, resource.path), '?', resource.query)
 
 include("object.jl")
 
@@ -69,18 +87,18 @@ delete(x::Object; kw...) = delete(x.store, x.key; kw...)
 
 # generic methods that dispatch on store type
 list(x::AWS.Bucket; kw...) = S3.list(x; kw...)
-get(x::AWS.Bucket, key::String, out::ResponseBodyType=nothing; kw...) = S3.get(x, key, out; kw...)
-head(x::AWS.Bucket, key::String; kw...) = S3.head(x, key; kw...)
-exists(x::AWS.Bucket, key::String; kw...) = S3.exists(x, key; kw...)
-put(x::AWS.Bucket, key::String, in::RequestBodyType; kw...) = S3.put(x, key, in; kw...)
-delete(x::AWS.Bucket, key::String; kw...) = S3.delete(x, key; kw...)
+get(x::AWS.Bucket, key::API.Resource, out::ResponseBodyType=nothing; kw...) = S3.get(x, key, out; kw...)
+head(x::AWS.Bucket, key::API.Resource; kw...) = S3.head(x, key; kw...)
+exists(x::AWS.Bucket, key::API.Resource; kw...) = S3.exists(x, key; kw...)
+put(x::AWS.Bucket, key::API.Resource, in::RequestBodyType; kw...) = S3.put(x, key, in; kw...)
+delete(x::AWS.Bucket, key::API.Resource; kw...) = S3.delete(x, key; kw...)
 
 list(x::Azure.Container; kw...) = Blobs.list(x; kw...)
-get(x::Azure.Container, key::String, out::ResponseBodyType=nothing; kw...) = Blobs.get(x, key, out; kw...)
-head(x::Azure.Container, key::String; kw...) = Blobs.head(x, key; kw...)
-exists(x::Azure.Container, key::String; kw...) = Blobs.exists(x, key; kw...)
-put(x::Azure.Container, key::String, in::RequestBodyType; kw...) = Blobs.put(x, key, in; kw...)
-delete(x::Azure.Container, key::String; kw...) = Blobs.delete(x, key; kw...)
+get(x::Azure.Container, key::API.Resource, out::ResponseBodyType=nothing; kw...) = Blobs.get(x, key, out; kw...)
+head(x::Azure.Container, key::API.Resource; kw...) = Blobs.head(x, key; kw...)
+exists(x::Azure.Container, key::API.Resource; kw...) = Blobs.exists(x, key; kw...)
+put(x::Azure.Container, key::API.Resource, in::RequestBodyType; kw...) = Blobs.put(x, key, in; kw...)
+delete(x::Azure.Container, key::API.Resource; kw...) = Blobs.delete(x, key; kw...)
 
 function get(url::AbstractString, out::ResponseBodyType=nothing; region=nothing, nowarn::Bool=false, kw...)
     store, key = parseURLForDispatch(url, region, nowarn)

--- a/src/blobs.jl
+++ b/src/blobs.jl
@@ -48,9 +48,9 @@ get(args...; kw...) = API.getObjectImpl(args...; kw...)
 
 API.headObject(x::Container, url, headers; kw...) = Azure.head(url; headers, kw...)
 head(x::Object; kw...) = head(x.store, x.key; credentials=x.credentials, kw...)
-head(x::Container, key::String; kw...) = API.headObjectImpl(x, key; kw...)
+head(x::Container, key::API.Resource; kw...) = API.headObjectImpl(x, key; kw...)
 exists(x::Object; kw...) = exists(x.store, x.key; credentials=x.credentials, kw...)
-exists(x::Container, key::String; kw...) = API.existsObjectImpl(x, key; kw...)
+exists(x::Container, key::API.Resource; kw...) = API.existsObjectImpl(x, key; kw...)
 
 put(args...; kw...) = API.putObjectImpl(args...; kw...)
 put(x::Object; kw...) = put(x.store, x.key; credentials=x.credentials, kw...)
@@ -71,7 +71,7 @@ function API.completeMultipartUpload(x::Container, url, eTags, uploadId; kw...)
     return API.etag(HTTP.header(resp, "ETag"))
 end
 
-delete(x::Container, key::String; kw...) = Azure.delete(API.makeURL(x, key); kw...)
+delete(x::Container, key::API.Resource; kw...) = Azure.delete(API.makeURL(x, key); kw...)
 delete(x::Object; kw...) = delete(x.store, x.key; credentials=x.credentials, kw...)
 
 for func in (:list, :get, :head, :exists, :put, :delete)
@@ -79,7 +79,8 @@ for func in (:list, :get, :head, :exists, :put, :delete)
         ok, host, account, container, blob = parseAzureAccountContainerBlob(url; parseLocal=parseLocal)
         ok || throw(ArgumentError("invalid url for Blobs.$($func): `$url`"))
         if blob !== nothing
-            return $func(Azure.Container(container, account; host), blob, args...; kw...)
+            resource = API.parsedURLResource(blob)
+            return $func(Azure.Container(container, account; host), resource, args...; kw...)
         else
             return $func(Azure.Container(container, account; host), args...; kw...)
         end

--- a/src/get.jl
+++ b/src/get.jl
@@ -22,7 +22,7 @@ function listObjectsImpl(x::AbstractStore;
     return contents
 end
 
-function headObjectImpl(x::AbstractStore, key::String;
+function headObjectImpl(x::AbstractStore, key::Resource;
     multipartThreshold::Int=MULTIPART_THRESHOLD,
     allowMultipart::Bool=true,
     headers=HTTP.Headers(), kw...)
@@ -33,7 +33,7 @@ function headObjectImpl(x::AbstractStore, key::String;
     return Dict(headObject(x, url, headers; kw...).headers)
 end
 
-function existsObjectImpl(x::AbstractStore, key::String;
+function existsObjectImpl(x::AbstractStore, key::Resource;
     headers=HTTP.Headers(), kw...)
     url = makeURL(x, key)
     request_kw = merge((; kw...), (; status_exception=false))
@@ -105,7 +105,7 @@ function _check_buffer_too_small_exception(@nospecialize(e::Exception))
     return e
 end
 
-function getObjectImpl(x::AbstractStore, key::String, out::ResponseBodyType=nothing;
+function getObjectImpl(x::AbstractStore, key::Resource, out::ResponseBodyType=nothing;
     multipartThreshold::Int=MULTIPART_THRESHOLD,
     partSize::Int=MULTIPART_SIZE,
     batchSize::Int=defaultBatchSize(),

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -81,6 +81,13 @@ function validate_account_name(account)
     return account
 end
 
+function _validate_url_resource(resource, validate)
+    value = String(resource)
+    path = first(split(value, '?'; limit=2, keepempty=true))
+    validate(path)
+    return value
+end
+
 function _validate_azure(ok::Bool, host, account, container, blob)
     return (
         ok,
@@ -88,7 +95,7 @@ function _validate_azure(ok::Bool, host, account, container, blob)
         isnothing(host) ? nothing : replace(String(host), r"^azure"i => "http"; count=1),
         String(validate_account_name(account)),
         isnothing(container) ? "" : String(validate_container_name(container)),
-        isnothing(blob) ? "" : String(validate_blob(blob)),
+        isnothing(blob) ? "" : _validate_url_resource(blob, validate_blob),
     )
 end
 
@@ -100,7 +107,7 @@ function _validate_aws(ok::Bool, accelerate, host, bucket, region, key)
         isnothing(host) ? nothing : replace(String(host), r"^(s|S)3" => "http"; count=1),
         String(validate_bucket_name(bucket, accelerate)),
         isnothing(region) || isempty(region) ? "" : String(validate_region(region)),
-        isnothing(key) ? "" : String(validate_key(key)),
+        isnothing(key) ? "" : _validate_url_resource(key, validate_key),
     )
 end
 
@@ -183,9 +190,9 @@ function parseURLForDispatch(url, region, nowarn)
         nowarn || @warn "`region` keyword argument not provided to `CloudStore.get` and undetected from url.  Defaulting to `us-east-1`"
         region = AWS.AWS_DEFAULT_REGION
     end
-    ok && return (AWS.Bucket(bucket, region; accelerate, host), key)
+    ok && return (AWS.Bucket(bucket, region; accelerate, host), API.parsedURLResource(key))
     ok, host, account, container, blob = parseAzureAccountContainerBlob(url)
-    ok && return (Azure.Container(container, account; host), blob)
+    ok && return (Azure.Container(container, account; host), API.parsedURLResource(blob))
     # ok, bucket, object = parseGCPBucketObject(url)
     # ok && return (GCP.Bucket(bucket), object)
     error("couldn't determine cloud from string url: `$url`")

--- a/src/put.jl
+++ b/src/put.jl
@@ -65,7 +65,7 @@ end
 compressorstream(zlibng) = zlibng ? CodecZlibNG.GzipCompressorStream : CodecZlib.GzipCompressorStream
 compressor(zlibng) = zlibng ? CodecZlibNG.GzipCompressor : CodecZlib.GzipCompressor
 
-function putObjectImpl(x::AbstractStore, key::String, in::RequestBodyType;
+function putObjectImpl(x::AbstractStore, key::Resource, in::RequestBodyType;
     multipartThreshold::Int=MULTIPART_THRESHOLD,
     partSize::Int=MULTIPART_SIZE,
     batchSize::Int=defaultBatchSize(),
@@ -81,7 +81,7 @@ function putObjectImpl(x::AbstractStore, key::String, in::RequestBodyType;
         body = prepBody(in, compress, zlibng)
         resp = putObject(x, key, body; credentials, kw...)
         wbytes[] = get(resp.request.context, :nbytes_written, 0)
-        obj = Object(x, credentials, key, N, etag(HTTP.header(resp, "ETag")))
+        obj = Object(x, credentials, resourceKey(key), N, etag(HTTP.header(resp, "ETag")))
         @goto done
     end
     # multipart upload
@@ -124,7 +124,7 @@ function putObjectImpl(x::AbstractStore, key::String, in::RequestBodyType;
         in isa String && close(body)
     end
     eTag = completeMultipartUpload(x, url, eTags, uploadState; credentials, kw...)
-    obj = Object(x, credentials, key, N, eTag)
+    obj = Object(x, credentials, resourceKey(key), N, eTag)
 @label done
     end_time = time()
     bytes = wbytes[]

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -34,9 +34,9 @@ get(args...; kw...) = API.getObjectImpl(args...; kw...)
 
 API.headObject(x::Bucket, url, headers; kw...) = AWS.head(url; headers, service="s3", kw...)
 head(x::Object; kw...) = head(x.store, x.key; credentials=x.credentials, kw...)
-head(x::Bucket, key::String; kw...) = API.headObjectImpl(x, key; kw...)
+head(x::Bucket, key::API.Resource; kw...) = API.headObjectImpl(x, key; kw...)
 exists(x::Object; kw...) = exists(x.store, x.key; credentials=x.credentials, kw...)
-exists(x::Bucket, key::String; kw...) = API.existsObjectImpl(x, key; kw...)
+exists(x::Bucket, key::API.Resource; kw...) = API.existsObjectImpl(x, key; kw...)
 
 put(args...; kw...) = API.putObjectImpl(args...; kw...)
 put(x::Object; kw...) = put(x.store, x.key; credentials=x.credentials, kw...)
@@ -59,7 +59,7 @@ function API.completeMultipartUpload(x::Bucket, url, eTags, uploadId; kw...)
     return API.etag(HTTP.header(resp, "ETag"))
 end
 
-delete(x::Bucket, key; kw...) = AWS.delete(API.makeURL(x, key); service="s3", kw...)
+delete(x::Bucket, key::API.Resource; kw...) = AWS.delete(API.makeURL(x, key); service="s3", kw...)
 delete(x::Object; kw...) = delete(x.store, x.key; credentials=x.credentials, kw...)
 
 for func in (:list, :get, :head, :exists, :put, :delete)
@@ -71,7 +71,8 @@ for func in (:list, :get, :head, :exists, :put, :delete)
             region = AWS.AWS_DEFAULT_REGION
         end
         if key !== nothing
-            return $func(S3.Bucket(bucket, region; accelerate, host), key, args...; kw...)
+            resource = API.parsedURLResource(key)
+            return $func(S3.Bucket(bucket, region; accelerate, host), resource, args...; kw...)
         else
             return $func(S3.Bucket(bucket, region; accelerate, host), args...; kw...)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using CodecZlib
 import HTTP
 import Sockets
 using HTTP: ConnectError, StatusError
-using Sockets: DNSError
+using Sockets: DNSError, IPv4, listenany
 using ExceptionUnwrapping: unwrap_exception
 
 bytes(x) = codeunits(x)
@@ -74,6 +74,51 @@ RecordingStore(; fail_part=nothing) = RecordingStore(
     @test CloudStore.API.makeURL(store, "plus+plus") == "https://recording.example/plus%2Bplus"
     @test CloudStore.API.makeURL(store, "hash#hash") == "https://recording.example/hash%23hash"
     @test CloudStore.API.makeURL(store, "unicode-ü") == "https://recording.example/unicode-%C3%BC"
+    @test CloudStore.API.makeURL(store, "literal?mark") == "https://recording.example/literal%3Fmark"
+    signed = CloudStore.API.parsedURLResource("key?X-Amz-Signature=a%2Fb&partNumber=1")
+    @test CloudStore.API.makeURL(store, signed) ==
+        "https://recording.example/key?X-Amz-Signature=a%2Fb&partNumber=1"
+end
+
+@testset "signed URL request targets" begin
+    port, socket = listenany(IPv4(0), 20_000)
+    close(socket)
+    targets = Channel{String}(4)
+    server = HTTP.serve!(port; verbose=false) do request
+        put!(targets, request.target)
+        return HTTP.Response(200, ["Content-Length" => "2"], "ok")
+    end
+    try
+        s3_query = "X-Amz-Signature=a%2Fb&X-Amz-SignedHeaders=host"
+        @test S3.get(
+            "http://127.0.0.1:$port/bucket-name/key?$s3_query";
+            parseLocal=true,
+            nowarn=true,
+            allowMultipart=false,
+        ) == b"ok"
+        @test take!(targets) == "/bucket-name/key?$s3_query"
+        @test S3.exists(
+            "http://127.0.0.1:$port/bucket-name/key?$s3_query";
+            parseLocal=true,
+            nowarn=true,
+        )
+        @test take!(targets) == "/bucket-name/key?$s3_query"
+
+        azure_query = "sv=2023-11-03&sig=c%2Fd&sp=r"
+        @test Blobs.get(
+            "azure://127.0.0.1:$port/account/container/blob?$azure_query";
+            parseLocal=true,
+            allowMultipart=false,
+        ) == b"ok"
+        @test take!(targets) == "/account/container/blob?$azure_query"
+        @test Blobs.exists(
+            "azure://127.0.0.1:$port/account/container/blob?$azure_query";
+            parseLocal=true,
+        )
+        @test take!(targets) == "/account/container/blob?$azure_query"
+    finally
+        close(server)
+    end
 end
 
 @testset "object existence" begin
@@ -664,6 +709,13 @@ end
         @test blob == parts[5]
     end
 
+
+    azure_sas = "?sp=r&sig=$("a"^1500)"
+    ok, host, account, container, blob = CloudStore.parseAzureAccountContainerBlob(
+        "https://myaccount.blob.core.windows.net/mycontainer/myblob$azure_sas")
+    @test (ok, host, account, container, blob) ==
+        (true, nothing, "myaccount", "mycontainer", "myblob$azure_sas")
+
     s3 = [
         ("https://bucket-name.s3-accelerate.us-east-1.amazonaws.com/key-name", (true, true, nothing, "bucket-name", "us-east-1", "key-name")),
         ("https://bucket-name.s3-accelerate.us-east-1.amazonaws.com", (true, true, nothing, "bucket-name", "us-east-1", "")),
@@ -711,6 +763,13 @@ end
         @test reg == parts[5]
         @test key == parts[6]
     end
+
+
+    aws_query = "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=$("b"^1500)"
+    ok, accelerate, host, bucket, reg, key = CloudStore.parseAWSBucketRegionKey(
+        "https://bucket-name.s3.us-east-1.amazonaws.com/key-name$aws_query")
+    @test (ok, accelerate, host, bucket, reg, key) ==
+        (true, false, nothing, "bucket-name", "us-east-1", "key-name$aws_query")
 
     # Only accept https, not http
     invalid_azure = [


### PR DESCRIPTION
## Summary

- validate only the object path portion of S3 and Azure URLs
- preserve the raw signed query string when CloudStore rebuilds the request URL
- keep literal `?` characters in direct object keys percent-encoded
- cover long signatures and exact request targets for S3 and Azure

Fixes JuliaServices/CloudStore.jl#38.

## Validation

- full CloudStore test suite passed
- signed URL target tests: 4 passed
- local MinIO and Azurite integration tests passed

Co-authored by Codex
