### PR TITLE
Add transfer progress callbacks

### DIFF
--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -79,9 +79,24 @@ using .API
 include("parse.jl")
 
 # generic dispatches
+"""
+    CloudStore.get(source[, output]; progress=nothing, kwargs...)
+
+Download an object. When `progress` is a function, call it as
+`progress(total_bytes, transferred_bytes)` after completed transfer batches. This
+matches the callback order used by `Downloads.download`.
+"""
 get(x::Object, out::ResponseBodyType=nothing; kw...) = get(x.store, x.key, out; kw...)
 head(x::Object; kw...) = head(x.store, x.key; kw...)
 exists(x::Object; kw...) = exists(x.store, x.key; kw...)
+"""
+    CloudStore.put(destination, input; progress=nothing, kwargs...)
+
+Upload an object. When `progress` is a function, call it as
+`progress(total_bytes, transferred_bytes)` after completed transfer batches. For a
+compressed multipart upload, `total_bytes` is `0` because the final wire size is not
+known before compression finishes.
+"""
 put(x::Object, in::RequestBodyType; kw...) = put(x.store, x.key, in; kw...)
 delete(x::Object; kw...) = delete(x.store, x.key; kw...)
 

--- a/src/get.jl
+++ b/src/get.jl
@@ -114,6 +114,7 @@ function getObjectImpl(x::AbstractStore, key::Resource, out::ResponseBodyType=no
     decompress::Bool=false,
     zlibng::Bool=false,
     headers=HTTP.Headers(),
+    progress=nothing,
     lograte::Bool=false, kw...)
 
     # if user provided a buffer or signalled the max object size is < multipartThreshold
@@ -144,6 +145,7 @@ function getObjectImpl(x::AbstractStore, key::Resource, out::ResponseBodyType=no
     end
     # for tracking bitrate per second of overall download
     nbytes = Threads.Atomic{Int}(0)
+    progressReported = false
 
     # if the user doesn't want multipart or we know from objectMaxSize or length(out) that we're
     # < multipartThreshold, then we'll just do a single GET request, handle that case first since
@@ -245,6 +247,10 @@ function getObjectImpl(x::AbstractStore, key::Resource, out::ResponseBodyType=no
                 end
             end
         end
+        if progress !== nothing
+            progress(contentLength, nbytes[])
+            progressReported = true
+        end
     end
 
 @label done
@@ -266,6 +272,9 @@ function getObjectImpl(x::AbstractStore, key::Resource, out::ResponseBodyType=no
     end
     end_time = time()
     bytes = nbytes[]
+    if progress !== nothing && !progressReported
+        progress(bytes, bytes)
+    end
     gbits_per_second = bytes == 0 ? 0 : (((8 * bytes) / 1e9) / (end_time - start_time))
     lograte && @info "CloudStore.get complete with bandwidth: $(gbits_per_second) Gbps"
     return res

--- a/src/put.jl
+++ b/src/put.jl
@@ -72,11 +72,13 @@ function putObjectImpl(x::AbstractStore, key::Resource, in::RequestBodyType;
     allowMultipart::Bool=true,
     zlibng::Bool=false,
     compress::Bool=false, credentials=nothing,
+    progress=nothing,
     lograte::Bool=false, kw...)
 
     start_time = time()
     N = nbytes(in)
     wbytes = Threads.Atomic{Int}(0)
+    progressReported = false
     if N <= multipartThreshold || !allowMultipart
         body = prepBody(in, compress, zlibng)
         resp = putObject(x, key, body; credentials, kw...)
@@ -113,6 +115,10 @@ function putObjectImpl(x::AbstractStore, key::Resource, in::RequestBodyType;
             for (parteTag, wb) in results
                 push!(eTags, parteTag)
                 Threads.atomic_add!(wbytes, wb)
+                if progress !== nothing
+                    progress(compress ? 0 : N, wbytes[])
+                    progressReported = true
+                end
             end
         end
     finally
@@ -128,6 +134,9 @@ function putObjectImpl(x::AbstractStore, key::Resource, in::RequestBodyType;
 @label done
     end_time = time()
     bytes = wbytes[]
+    if progress !== nothing && !progressReported
+        progress(bytes, bytes)
+    end
     gbits_per_second = bytes == 0 ? 0 : (((8 * bytes) / 1e9) / (end_time - start_time))
     lograte && @info "CloudStore.put complete with bandwidth: $(gbits_per_second) Gbps"
     return obj

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,49 @@ RecordingStore(; fail_part=nothing) = RecordingStore(
     fail_part,
 )
 
+struct RecordingDownloadStore <: CloudBase.AbstractStore
+    baseurl::String
+    data::Vector{UInt8}
+end
+
+RecordingDownloadStore(data) = RecordingDownloadStore(
+    "https://recording.example/", Vector{UInt8}(data))
+
+function CloudStore.API.headObject(store::RecordingDownloadStore, url, _headers; kw...)
+    request = HTTP.Request("HEAD", url)
+    return HTTP.Response(
+        200,
+        ["Content-Length" => string(length(store.data))],
+        UInt8[];
+        request,
+    )
+end
+
+function CloudStore.API.getObject(
+    store::RecordingDownloadStore,
+    url,
+    headers;
+    response_stream=nothing,
+    kw...,
+)
+    range = HTTP.header(headers, "Range", "bytes=0-$(length(store.data) - 1)")
+    match_result = match(r"bytes=(\d+)-(\d+)", range)
+    first_byte = parse(Int, match_result[1]) + 1
+    last_byte = parse(Int, match_result[2]) + 1
+    part = store.data[first_byte:last_byte]
+    if response_stream !== nothing
+        copyto!(response_stream, part)
+    end
+    request = HTTP.Request("GET", url)
+    request.context[:nbytes] = length(part)
+    return HTTP.Response(
+        206,
+        ["Content-Length" => string(length(part))],
+        response_stream === nothing ? part : response_stream;
+        request,
+    )
+end
+
 @testset "object key URL encoding" begin
     store = RecordingStore()
     @test CloudStore.API.makeURL(store, "plain") == "https://recording.example/plain"
@@ -163,6 +206,44 @@ end
 function CloudStore.API.completeMultipartUpload(store::RecordingStore, _url, tags, _state; kw...)
     store.completed_tags = copy(tags)
     return "complete"
+end
+
+@testset "transfer progress callbacks" begin
+    data = collect(UInt8(1):UInt8(10))
+    download_updates = Tuple{Int,Int}[]
+    result = CloudStore.API.getObjectImpl(
+        RecordingDownloadStore(data),
+        "data.bin";
+        multipartThreshold=1,
+        partSize=4,
+        batchSize=2,
+        progress=(total, transferred) -> push!(download_updates, (total, transferred)),
+    )
+    @test result == data
+    @test download_updates == [(10, 8), (10, 10)]
+
+    single_updates = Tuple{Int,Int}[]
+    result = CloudStore.API.getObjectImpl(
+        RecordingDownloadStore(data),
+        "data.bin";
+        allowMultipart=false,
+        progress=(total, transferred) -> push!(single_updates, (total, transferred)),
+    )
+    @test result == data
+    @test single_updates == [(10, 10)]
+
+    upload_data = collect(UInt8(1):UInt8(16))
+    upload_updates = Tuple{Int,Int}[]
+    CloudStore.API.putObjectImpl(
+        RecordingStore(),
+        "data.bin",
+        upload_data;
+        multipartThreshold=1,
+        partSize=4,
+        batchSize=2,
+        progress=(total, transferred) -> push!(upload_updates, (total, transferred)),
+    )
+    @test upload_updates == [(16, 4), (16, 8), (16, 12), (16, 16)]
 end
 
 @testset "prepBody IOBuffer bounds" begin


### PR DESCRIPTION
## Summary

- add optional progress callbacks to object downloads and uploads
- use the callback order `(total_bytes, transferred_bytes)` from `Downloads.download`
- report progress after completed multipart batches
- report a zero total for compressed multipart uploads whose wire size is not known in advance

Fixes JuliaServices/CloudStore.jl#15.

## Validation

- full CloudStore test suite passed
- callback tests cover single and multipart downloads
- callback tests cover multipart uploads and exact byte counts
- local MinIO and Azurite integration tests passed

Co-authored by Codex
