### PR TITLE
Abort failed multipart uploads

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -24,4 +24,5 @@ CloudStore.Object
 ```@docs
 CloudStore.PrefetchedDownloadStream
 CloudStore.MultipartUploadStream
+CloudStore.abort
 ```

--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -7,7 +7,7 @@ import CloudBase: AWS, Azure, CloudTest
 module API
 
 export Object, PrefetchedDownloadStream, ResponseBodyType, RequestBodyType,
-    MultipartUploadStream
+    MultipartUploadStream, abort
 
 using HTTP, CodecZlib, CodecZlibNG, Mmap, TranscodingStreams
 import WorkerUtilities: OrderedSynchronizer
@@ -70,6 +70,7 @@ function putObject end
 function startMultipartUpload end
 function uploadPart end
 function completeMultipartUpload end
+function abortMultipartUpload end
 include("put.jl")
 
 end # module API

--- a/src/blobs.jl
+++ b/src/blobs.jl
@@ -71,6 +71,10 @@ function API.completeMultipartUpload(x::Container, url, eTags, uploadId; kw...)
     return API.etag(HTTP.header(resp, "ETag"))
 end
 
+# Azure Blob Storage has no abort operation for uncommitted blocks. The service
+# removes them automatically after its retention period.
+API.abortMultipartUpload(x::Container, url, uploadId; kw...) = nothing
+
 delete(x::Container, key::API.Resource; kw...) = Azure.delete(API.makeURL(x, key); kw...)
 delete(x::Object; kw...) = delete(x.store, x.key; credentials=x.credentials, kw...)
 

--- a/src/object.jl
+++ b/src/object.jl
@@ -386,22 +386,25 @@ function _upload_task(io; kw...)
     try
         (part_n, upload_buffer) = take!(io.upload_queue)
         # upload the part
-        parteTag, wb = uploadPart(io.store, io.url, upload_buffer, part_n, io.uploadState; io.credentials, kw...)
-        Base.release(io.sem)
+        parteTag, _ = uploadPart(io.store, io.url, upload_buffer, part_n, io.uploadState; io.credentials, kw...)
         # add part eTag to our collection of eTags
         Base.@lock io.cond_wait begin
             if length(io.eTags) < part_n
                 resize!(io.eTags, part_n)
             end
             io.eTags[part_n] = parteTag
-            io.ntasks -= 1
-            notify(io.cond_wait)
         end
     catch e
         isopen(io.upload_queue) && close(io.upload_queue, e)
         Base.@lock io.cond_wait begin
             io.exc = e
-            notify(io.cond_wait, e, all=true, error=true)
+            notify(io.cond_wait, all=true)
+        end
+    finally
+        Base.release(io.sem)
+        Base.@lock io.cond_wait begin
+            io.ntasks -= 1
+            notify(io.cond_wait, all=true)
         end
     end
     return nothing
@@ -477,6 +480,8 @@ mutable struct MultipartUploadStream{T <: AbstractStore} <: IO
     ntasks::Int
     exc::Union{Exception, Nothing}
     sem::Base.Semaphore
+    closed::Bool
+    aborted::Bool
 
     function MultipartUploadStream(
         store::AWS.Bucket,
@@ -485,6 +490,8 @@ mutable struct MultipartUploadStream{T <: AbstractStore} <: IO
         concurrent_writes_to_channel::Int=(4 * Threads.nthreads()),
         kw...
     )
+        concurrent_writes_to_channel > 0 || throw(ArgumentError(
+            "`concurrent_writes_to_channel` must be positive"))
         url = makeURL(store, key)
         uploadState = API.startMultipartUpload(store, key; credentials, kw...)
         io = new{AWS.Bucket}(
@@ -498,7 +505,9 @@ mutable struct MultipartUploadStream{T <: AbstractStore} <: IO
             0,
             0,
             nothing,
-            Base.Semaphore(concurrent_writes_to_channel)
+            Base.Semaphore(concurrent_writes_to_channel),
+            false,
+            false,
         )
         return io
     end
@@ -510,6 +519,8 @@ mutable struct MultipartUploadStream{T <: AbstractStore} <: IO
         concurrent_writes_to_channel::Int=(4 * Threads.nthreads()),
         kw...
     )
+        concurrent_writes_to_channel > 0 || throw(ArgumentError(
+            "`concurrent_writes_to_channel` must be positive"))
         url = makeURL(store, key)
         uploadState = API.startMultipartUpload(store, key; credentials, kw...)
         io = new{Azure.Container}(
@@ -523,7 +534,9 @@ mutable struct MultipartUploadStream{T <: AbstractStore} <: IO
             0,
             0,
             nothing,
-            Base.Semaphore(concurrent_writes_to_channel)
+            Base.Semaphore(concurrent_writes_to_channel),
+            false,
+            false,
         )
         return io
     end
@@ -535,11 +548,15 @@ mutable struct MultipartUploadStream{T <: AbstractStore} <: IO
         io = MultipartUploadStream(args...; kw...)
         try
             f(io)
-            wait(io)
             close(io; kw...)
-        catch e
-            # todo, we need a function here to signal abort to S3/Blobs. We don't have that
-            # yet in CloudStore.jl
+        catch
+            if !io.closed && !io.aborted
+                try
+                    abort(io; kw...)
+                catch abort_exception
+                    @warn "Failed to abort multipart upload" exception=(abort_exception, catch_backtrace())
+                end
+            end
             rethrow()
         end
     end
@@ -547,43 +564,99 @@ end
 
 # Writes a data chunk to the channel and spawn
 function Base.write(io::MultipartUploadStream, bytes::Vector{UInt8}; kw...)
-    local part_n
-    Base.@lock io.cond_wait begin
-        io.ntasks += 1
-        io.cur_part_id += 1
-        part_n = io.cur_part_id
-        notify(io.cond_wait)
-    end
+    isopen(io) || throw(InvalidStateException("multipart upload is closed", :closed))
     Base.acquire(io.sem)
-    # We expect the data chunks to be written in order in the channel.
-    put!(io.upload_queue, (part_n, bytes))
-    Threads.@spawn _upload_task($io; $(kw)...)
+    local part_n
+    registered = false
+    try
+        Base.@lock io.cond_wait begin
+            isopen(io) || throw(InvalidStateException(
+                "multipart upload is closed", :closed))
+            isnothing(io.exc) || throw(io.exc)
+            io.ntasks += 1
+            io.cur_part_id += 1
+            part_n = io.cur_part_id
+            registered = true
+            notify(io.cond_wait)
+        end
+        # We expect the data chunks to be written in order in the channel.
+        put!(io.upload_queue, (part_n, bytes))
+        Threads.@spawn _upload_task($io; $(kw)...)
+    catch
+        Base.release(io.sem)
+        if registered
+            Base.@lock io.cond_wait begin
+                io.ntasks -= 1
+                notify(io.cond_wait, all=true)
+            end
+        end
+        rethrow()
+    end
     return nothing
 end
 
 # Waits for all parts to be uploaded
 function Base.wait(io::MultipartUploadStream)
-    try
-        Base.@lock io.cond_wait begin
-            while true
-                !isnothing(io.exc) && throw(io.exc)
-                io.ntasks == 0 && break
-                wait(io.cond_wait)
-            end
+    Base.@lock io.cond_wait begin
+        while io.ntasks != 0
+            wait(io.cond_wait)
         end
-    catch e
-        rethrow()
+        isnothing(io.exc) || throw(io.exc)
     end
+    return nothing
 end
+
+function _wait_for_upload_tasks(io::MultipartUploadStream)
+    Base.@lock io.cond_wait begin
+        while io.ntasks != 0
+            wait(io.cond_wait)
+        end
+    end
+    return nothing
+end
+
+"""
+    CloudStore.abort(io::MultipartUploadStream; kwargs...)
+
+Wait for active part requests, then abort the multipart upload. S3 removes the
+uploaded parts immediately. Azure has no matching abort request and removes
+uncommitted blocks after its service retention period.
+"""
+function abort(io::MultipartUploadStream; credentials=io.credentials, kw...)
+    Base.@lock io.cond_wait begin
+        io.closed && return nothing
+        io.aborted && return nothing
+        # Change state under the writer lock so no new part can register.
+        io.aborted = true
+    end
+    isopen(io.upload_queue) && close(io.upload_queue)
+    _wait_for_upload_tasks(io)
+    return API.abortMultipartUpload(
+        io.store, io.url, io.uploadState; credentials, kw...)
+end
+
+Base.isopen(io::MultipartUploadStream) =
+    !io.closed && !io.aborted && isopen(io.upload_queue)
 
 # When there are no more data chunks to upload, this function closes the channel and sends
 # a POST request with a single id for the entire upload.
-function Base.close(io::MultipartUploadStream; kw...)
+function Base.close(io::MultipartUploadStream; credentials=io.credentials, kw...)
+    io.closed && return nothing
+    io.aborted && throw(InvalidStateException("multipart upload was aborted", :closed))
     try
-        close(io.upload_queue)
-        return API.completeMultipartUpload(io.store, io.url, io.eTags, io.uploadState; kw...)
+        isopen(io.upload_queue) && close(io.upload_queue)
+        wait(io)
+        result = API.completeMultipartUpload(
+            io.store, io.url, io.eTags, io.uploadState; credentials, kw...)
+        io.closed = true
+        return result
     catch e
         io.exc = e
+        try
+            abort(io; credentials, kw...)
+        catch abort_exception
+            @warn "Failed to abort multipart upload" exception=(abort_exception, catch_backtrace())
+        end
         rethrow()
     end
 end

--- a/src/put.jl
+++ b/src/put.jl
@@ -90,46 +90,56 @@ function putObjectImpl(x::AbstractStore, key::Resource, in::RequestBodyType;
     uploadState = startMultipartUpload(x, key; credentials, kw...)
     url = makeURL(x, key)
     eTags = String[]
-    body = prepBodyMultipart(in, compress, zlibng)
-    partNumber = 0
+    local eTag
     try
-        # Compression can make incompressible input larger than its source, so the
-        # source byte count cannot safely bound the number of output parts.
-        while !eof(body)
-            parts = Tuple{Int,Any}[]
-            for _ = 1:batchSize
-                eof(body) && break
-                part = _read(body, partSize)
-                isempty(part) && break
-                partNumber += 1
-                push!(parts, (partNumber, part))
-            end
-            isempty(parts) && break
-            results = Vector{Tuple{String,Int}}(undef, length(parts))
-            @sync for index in eachindex(parts)
-                n, part = parts[index]
-                Threads.@spawn begin
-                    results[$index] = uploadPart(x, url, $part, $n, uploadState; credentials, kw...)
+        body = prepBodyMultipart(in, compress, zlibng)
+        partNumber = 0
+        try
+            # Compression can make incompressible input larger than its source, so the
+            # source byte count cannot safely bound the number of output parts.
+            while !eof(body)
+                parts = Tuple{Int,Any}[]
+                for _ = 1:batchSize
+                    eof(body) && break
+                    part = _read(body, partSize)
+                    isempty(part) && break
+                    partNumber += 1
+                    push!(parts, (partNumber, part))
+                end
+                isempty(parts) && break
+                results = Vector{Tuple{String,Int}}(undef, length(parts))
+                @sync for index in eachindex(parts)
+                    n, part = parts[index]
+                    Threads.@spawn begin
+                        results[$index] = uploadPart(x, url, $part, $n, uploadState; credentials, kw...)
+                    end
+                end
+                for (parteTag, wb) in results
+                    push!(eTags, parteTag)
+                    Threads.atomic_add!(wbytes, wb)
+                    if progress !== nothing
+                        progress(compress ? 0 : N, wbytes[])
+                        progressReported = true
+                    end
                 end
             end
-            for (parteTag, wb) in results
-                push!(eTags, parteTag)
-                Threads.atomic_add!(wbytes, wb)
-                if progress !== nothing
-                    progress(compress ? 0 : N, wbytes[])
-                    progressReported = true
-                end
+        finally
+            if body isa compressorstream(zlibng)
+                wrapped = body.stream
+                close(body)
+                body = wrapped
             end
+            in isa String && close(body)
         end
-    finally
-        if body isa compressorstream(zlibng)
-            wrapped = body.stream
-            close(body)
-            body = wrapped
+        eTag = completeMultipartUpload(x, url, eTags, uploadState; credentials, kw...)
+    catch
+        try
+            abortMultipartUpload(x, url, uploadState; credentials, kw...)
+        catch abort_exception
+            @warn "Failed to abort multipart upload" exception=(abort_exception, catch_backtrace())
         end
-        in isa String && close(body)
+        rethrow()
     end
-    eTag = completeMultipartUpload(x, url, eTags, uploadState; credentials, kw...)
     obj = Object(x, credentials, resourceKey(key), N, eTag)
 @label done
     end_time = time()

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -59,6 +59,11 @@ function API.completeMultipartUpload(x::Bucket, url, eTags, uploadId; kw...)
     return API.etag(HTTP.header(resp, "ETag"))
 end
 
+function API.abortMultipartUpload(x::Bucket, url, uploadId; kw...)
+    return AWS.delete(url;
+        query=Dict("uploadId" => uploadId), service="s3", kw...)
+end
+
 delete(x::Bucket, key::API.Resource; kw...) = AWS.delete(API.makeURL(x, key); service="s3", kw...)
 delete(x::Object; kw...) = delete(x.store, x.key; credentials=x.credentials, kw...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,7 @@ mutable struct RecordingStore <: CloudBase.AbstractStore
     parts::Dict{Int,Vector{UInt8}}
     completed_tags::Vector{String}
     fail_part::Union{Nothing,Int}
+    aborted::Bool
 end
 
 RecordingStore(; fail_part=nothing) = RecordingStore(
@@ -62,6 +63,7 @@ RecordingStore(; fail_part=nothing) = RecordingStore(
     Dict{Int,Vector{UInt8}}(),
     String[],
     fail_part,
+    false,
 )
 
 struct RecordingDownloadStore <: CloudBase.AbstractStore
@@ -208,6 +210,11 @@ function CloudStore.API.completeMultipartUpload(store::RecordingStore, _url, tag
     return "complete"
 end
 
+function CloudStore.API.abortMultipartUpload(store::RecordingStore, _url, _state; kw...)
+    store.aborted = true
+    return nothing
+end
+
 @testset "transfer progress callbacks" begin
     data = collect(UInt8(1):UInt8(10))
     download_updates = Tuple{Int,Int}[]
@@ -314,6 +321,7 @@ end
     @test store.completed_tags == ["etag-$i" for i in 1:length(store.parts)]
     @test obj.size == length(data)
     @test isopen(input)
+    @test !store.aborted
 
     # A failed early part must not leave later workers blocked waiting for its tag,
     # and cleanup must still leave caller-owned IO usable.
@@ -336,6 +344,7 @@ end
     @test err !== nothing
     @test occursin("synthetic upload failure", sprint(showerror, err))
     @test isopen(failing_input)
+    @test failing_store.aborted
 end
 
 @testset "CloudStore.jl" begin
@@ -1363,6 +1372,24 @@ end
         CloudStore.close(mus_obj; credentials)
         obj = CloudStore.Object(bucket, "test.csv"; credentials)
         @test length(obj) == sizeof(multicsv)
+    end
+end
+
+@testset "CloudStore.MultipartUploadStream abort - S3" begin
+    Minio.with(; debug=true) do conf
+        credentials, bucket = conf
+        @test_throws ArgumentError CloudStore.MultipartUploadStream(
+            bucket, "invalid.bin"; credentials, concurrent_writes_to_channel=0)
+
+        io = CloudStore.MultipartUploadStream(bucket, "aborted.bin"; credentials)
+        write(io, fill(0x2a, 5_500_000))
+        wait(io)
+        CloudStore.abort(io; credentials)
+
+        @test io.aborted
+        @test !isopen(io)
+        @test_throws InvalidStateException write(io, UInt8[0x01])
+        @test_throws StatusError S3.head(bucket, "aborted.bin"; credentials)
     end
 end
 


### PR DESCRIPTION
## Summary

- abort S3 multipart uploads when a high-level upload fails
- add `CloudStore.abort` for explicit `MultipartUploadStream` cleanup
- make stream close and do-block failures abort automatically
- drain failed worker tasks and always release semaphore permits
- reject writes after close or abort

Addresses the portable cleanup part of JuliaServices/CloudStore.jl#3.

## Root cause

A failed part closed the worker channel but did not release its semaphore permit or decrement the active-task count. The stream could then block while waiting. High-level and streaming failure paths also left the S3 upload and its uploaded parts active.

S3 has an explicit AbortMultipartUpload operation. Azure Blob Storage has no matching abort request for uncommitted blocks, so the Azure method changes local stream state and lets the service remove uncommitted blocks under its retention policy.

The other requests in issue #3 are not one portable operation. S3 part listing and replacement semantics differ from Azure block-list commit semantics. This PR keeps the common API limited to safe lifecycle cleanup.

## Validation

- full CloudStore test suite passed
- synthetic part failure confirms that high-level cleanup calls abort
- MinIO integration confirms explicit abort, closed-stream behavior, and no completed object
- existing S3 and Azure multipart stream integration tests passed

Co-authored by Codex
