### PR TITLE
Support content types on object uploads

### DIFF
--- a/src/CloudStore.jl
+++ b/src/CloudStore.jl
@@ -91,9 +91,15 @@ get(x::Object, out::ResponseBodyType=nothing; kw...) = get(x.store, x.key, out; 
 head(x::Object; kw...) = head(x.store, x.key; kw...)
 exists(x::Object; kw...) = exists(x.store, x.key; kw...)
 """
-    CloudStore.put(destination, input; progress=nothing, kwargs...)
+    CloudStore.put(store, key, input; contentType=nothing, headers=HTTP.Headers(), progress=nothing, kwargs...)
+    CloudStore.put(object, input; contentType=nothing, headers=HTTP.Headers(), progress=nothing, kwargs...)
+    CloudStore.put(url, input; contentType=nothing, headers=HTTP.Headers(), progress=nothing, kwargs...)
 
-Upload an object. When `progress` is a function, call it as
+Upload `input`. Set `contentType` to a MIME type such as `"text/csv"` to store it
+as the object's `Content-Type`. The setting applies to single-request and multipart
+uploads.
+
+When `progress` is a function, call it as
 `progress(total_bytes, transferred_bytes)` after completed transfer batches. For a
 compressed multipart upload, `total_bytes` is `0` because the final wire size is not
 known before compression finishes.

--- a/src/blobs.jl
+++ b/src/blobs.jl
@@ -55,19 +55,29 @@ exists(x::Container, key::API.Resource; kw...) = API.existsObjectImpl(x, key; kw
 put(args...; kw...) = API.putObjectImpl(args...; kw...)
 put(x::Object; kw...) = put(x.store, x.key; credentials=x.credentials, kw...)
 
-API.putObject(x::Container, key, body; kw...) = Azure.put(API.makeURL(x, key), ["x-ms-blob-type" => "BlockBlob"], body; kw...)
+function API.putObject(x::Container, key, body;
+    contentType=nothing, headers=HTTP.Headers(), kw...)
+    HTTP.setheader(headers, "x-ms-blob-type" => "BlockBlob")
+    contentType === nothing || HTTP.setheader(headers, "Content-Type" => String(contentType))
+    return Azure.put(API.makeURL(x, key), headers, body; kw...)
+end
 
-API.startMultipartUpload(x::Container, key; kw...) = nothing
+API.startMultipartUpload(x::Container, key;
+    contentType=nothing, headers=HTTP.Headers(), kw...) = nothing
 
 function API.uploadPart(x::Container, url, part, partNumber, uploadId; kw...)
     blockid = base64encode(lpad(partNumber - 1, 64, '0'))
-    resp = Azure.put(url, [], part; query=Dict("comp" => "block", "blockid" => blockid), kw...)
+    resp = Azure.put(url, [], part;
+        query=Dict("comp" => "block", "blockid" => blockid), kw...)
     return (blockid, Base.get(resp.request.context, :nbytes_written, 0))
 end
 
-function API.completeMultipartUpload(x::Container, url, eTags, uploadId; kw...)
+function API.completeMultipartUpload(x::Container, url, eTags, uploadId;
+    contentType=nothing, headers=HTTP.Headers(), kw...)
+    contentType === nothing || HTTP.setheader(
+        headers, "x-ms-blob-content-type" => String(contentType))
     body = XMLDict.node_xml("BlockList", Dict("Latest" => eTags))
-    resp = Azure.put(url; query=Dict("comp" => "blocklist"), body, kw...)
+    resp = Azure.put(url, headers, body; query=Dict("comp" => "blocklist"), kw...)
     return API.etag(HTTP.header(resp, "ETag"))
 end
 

--- a/src/put.jl
+++ b/src/put.jl
@@ -73,6 +73,8 @@ function putObjectImpl(x::AbstractStore, key::Resource, in::RequestBodyType;
     zlibng::Bool=false,
     compress::Bool=false, credentials=nothing,
     progress=nothing,
+    contentType::Union{Nothing,AbstractString}=nothing,
+    headers=HTTP.Headers(),
     lograte::Bool=false, kw...)
 
     start_time = time()
@@ -81,13 +83,15 @@ function putObjectImpl(x::AbstractStore, key::Resource, in::RequestBodyType;
     progressReported = false
     if N <= multipartThreshold || !allowMultipart
         body = prepBody(in, compress, zlibng)
-        resp = putObject(x, key, body; credentials, kw...)
+        resp = putObject(x, key, body;
+            contentType, headers=copy(headers), credentials, kw...)
         wbytes[] = get(resp.request.context, :nbytes_written, 0)
         obj = Object(x, credentials, resourceKey(key), N, etag(HTTP.header(resp, "ETag")))
         @goto done
     end
     # multipart upload
-    uploadState = startMultipartUpload(x, key; credentials, kw...)
+    uploadState = startMultipartUpload(x, key;
+        contentType, headers=copy(headers), credentials, kw...)
     url = makeURL(x, key)
     eTags = String[]
     local eTag
@@ -111,7 +115,8 @@ function putObjectImpl(x::AbstractStore, key::Resource, in::RequestBodyType;
                 @sync for index in eachindex(parts)
                     n, part = parts[index]
                     Threads.@spawn begin
-                        results[$index] = uploadPart(x, url, $part, $n, uploadState; credentials, kw...)
+                        results[$index] = uploadPart(
+                            x, url, $part, $n, uploadState; credentials, kw...)
                     end
                 end
                 for (parteTag, wb) in results
@@ -131,7 +136,8 @@ function putObjectImpl(x::AbstractStore, key::Resource, in::RequestBodyType;
             end
             in isa String && close(body)
         end
-        eTag = completeMultipartUpload(x, url, eTags, uploadState; credentials, kw...)
+        eTag = completeMultipartUpload(x, url, eTags, uploadState;
+            contentType, headers=copy(headers), credentials, kw...)
     catch
         try
             abortMultipartUpload(x, url, uploadState; credentials, kw...)

--- a/src/s3.jl
+++ b/src/s3.jl
@@ -41,19 +41,28 @@ exists(x::Bucket, key::API.Resource; kw...) = API.existsObjectImpl(x, key; kw...
 put(args...; kw...) = API.putObjectImpl(args...; kw...)
 put(x::Object; kw...) = put(x.store, x.key; credentials=x.credentials, kw...)
 
-API.putObject(x::Bucket, key, body; kw...) = AWS.put(API.makeURL(x, key), [], body; service="s3", kw...)
+function API.putObject(x::Bucket, key, body;
+    contentType=nothing, headers=HTTP.Headers(), kw...)
+    contentType === nothing || HTTP.setheader(headers, "Content-Type" => String(contentType))
+    return AWS.put(API.makeURL(x, key), headers, body; service="s3", kw...)
+end
 
-function API.startMultipartUpload(x::Bucket, key; kw...)
-    resp = AWS.post(API.makeURL(x, key); query=Dict("uploads" => ""), service="s3", retry_non_idempotent=true, kw...)
+function API.startMultipartUpload(x::Bucket, key;
+    contentType=nothing, headers=HTTP.Headers(), kw...)
+    contentType === nothing || HTTP.setheader(headers, "Content-Type" => String(contentType))
+    resp = AWS.post(API.makeURL(x, key), headers;
+        query=Dict("uploads" => ""), service="s3", retry_non_idempotent=true, kw...)
     return xml_dict(String(resp.body))["InitiateMultipartUploadResult"]["UploadId"]
 end
 
 function API.uploadPart(x::Bucket, url, part, partNumber, uploadId; kw...)
-    resp = AWS.put(url, [], part; query=Dict("partNumber" => string(partNumber), "uploadId" => uploadId), service="s3", kw...)
+    resp = AWS.put(url, [], part;
+        query=Dict("partNumber" => string(partNumber), "uploadId" => uploadId), service="s3", kw...)
     return (HTTP.header(resp, "ETag"), Base.get(resp.request.context, :nbytes_written, 0))
 end
 
-function API.completeMultipartUpload(x::Bucket, url, eTags, uploadId; kw...)
+function API.completeMultipartUpload(x::Bucket, url, eTags, uploadId;
+    contentType=nothing, headers=HTTP.Headers(), kw...)
     body = XMLDict.node_xml("CompleteMultipartUpload", Dict("Part" => [Dict("PartNumber" => string(i), "ETag" => eTag) for (i, eTag) in enumerate(eTags)]))
     resp = AWS.post(url; query=Dict("uploadId" => uploadId), body, service="s3", kw...)
     return API.etag(HTTP.header(resp, "ETag"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,13 @@ using ExceptionUnwrapping: unwrap_exception
 
 bytes(x) = codeunits(x)
 
+function header_value(headers, name)
+    for (key, value) in headers
+        lowercase(key) == lowercase(name) && return value
+    end
+    return ""
+end
+
 function stringfile(x)
     path, io = mktemp()
     write(io, x)
@@ -360,7 +367,7 @@ end
                 body = inBody(csv)
                 out = outType(csv, outBody)
                 println("in: $inBody, out: $outBody, single part, no compression")
-                obj = S3.put(bucket, "test.csv", body; credentials)
+                obj = S3.put(bucket, "test.csv", body; contentType="text/csv", credentials)
                 data = S3.get(bucket, "test.csv", out; objectMaxSize=sizeof(csv), credentials)
                 @test check(body, data)
                 resetOut!(out)
@@ -371,6 +378,7 @@ end
                 # object metadata
                 meta = S3.head(bucket, "test.csv"; credentials)
                 @test meta isa Dict && !isempty(meta)
+                @test header_value(meta, "Content-Type") == "text/csv"
 
                 # list
                 objs = S3.list(bucket; credentials)
@@ -409,9 +417,11 @@ end
                 mbody = inBody(multicsv);
                 out = outType(multicsv, outBody)
                 println("in: $inBody, out: $outBody, multipart, no compression")
-                obj = S3.put(bucket, "test3.csv", mbody; multipartThreshold=5_000_000, partSize=5_500_000, lograte=true, credentials)
+                obj = S3.put(bucket, "test3.csv", mbody; contentType="text/csv", multipartThreshold=5_000_000, partSize=5_500_000, lograte=true, credentials)
                 data = S3.get(bucket, "test3.csv", out; objectMaxSize=sizeof(multicsv), lograte=true, credentials)
                 @test check(mbody, data)
+                meta = S3.head(bucket, "test3.csv"; credentials)
+                @test header_value(meta, "Content-Type") == "text/csv"
                 resetOut!(out)
                 println("in: $inBody, out: $outBody, multipart, compression")
                 obj = S3.put(bucket, "test4.csv", mbody; compress=true, zlibng=true, multipartThreshold=5_000_000, partSize=5_500_000, credentials)
@@ -566,7 +576,7 @@ end
                 body = inBody(csv)
                 out = outType(csv, outBody)
                 println("in: $inBody, out: $outBody, single part, no compression")
-                obj = Blobs.put(container, "test.csv", body; credentials)
+                obj = Blobs.put(container, "test.csv", body; contentType="text/csv", credentials)
                 data = Blobs.get(container, "test.csv", out; credentials)
                 @test check(body, data)
                 resetOut!(out)
@@ -577,6 +587,7 @@ end
                 # object metadata
                 meta = Blobs.head(container, "test.csv"; credentials)
                 @test meta isa Dict && !isempty(meta)
+                @test header_value(meta, "Content-Type") == "text/csv"
 
                 # list
                 objs = Blobs.list(container; credentials)
@@ -616,9 +627,11 @@ end
                 mbody = inBody(multicsv);
                 out = outType(multicsv, outBody)
                 println("in: $inBody, out: $outBody, multipart, no compression")
-                obj = Blobs.put(container, "test3.csv", mbody; multipartThreshold=5_000_000, partSize=5_500_000, credentials)
+                obj = Blobs.put(container, "test3.csv", mbody; contentType="text/csv", multipartThreshold=5_000_000, partSize=5_500_000, credentials)
                 data = Blobs.get(container, "test3.csv", out; credentials)
                 @test check(mbody, data)
+                meta = Blobs.head(container, "test3.csv"; credentials)
+                @test header_value(meta, "Content-Type") == "text/csv"
                 resetOut!(out)
                 println("in: $inBody, out: $outBody, multipart, compression")
                 obj = Blobs.put(container, "test4.csv", mbody; compress=true, multipartThreshold=5_000_000, partSize=5_500_000, credentials)


### PR DESCRIPTION
## Summary

- add a `contentType` keyword to `CloudStore.put`, `S3.put`, and `Blobs.put`
- preserve the value for single-request and multipart uploads
- merge caller headers with Azure's required `x-ms-blob-type` header
- use each provider's correct multipart metadata request

Fixes JuliaServices/CloudStore.jl#4.

## Provider behavior

S3 stores the content type from CreateMultipartUpload. Azure stores it from Put Block List with `x-ms-blob-content-type`. Sending a normal `Content-Type` on the Azure block-list request only describes the XML request body and leaves the blob as `application/octet-stream`.

## Validation

- full CloudStore test suite passed
- MinIO tests verify content type after single and multipart uploads
- Azurite tests verify content type after single and multipart uploads
- all existing input and output forms remain covered

Co-authored by Codex
